### PR TITLE
fix(autoconfigure-dashscope): fix autoconfigure-dashscope

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeImageAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeImageAutoConfiguration.java
@@ -69,7 +69,7 @@ public class DashScopeImageAutoConfiguration {
 			.apiKey(resolved.apiKey())
 			.baseUrl(resolved.baseUrl())
 			.workSpaceId(resolved.workspaceId())
-			.restClientBuilder(restClientBuilderProvider.getIfAvailable())
+			.restClientBuilder(restClientBuilderProvider.getIfAvailable(RestClient::builder))
 			.responseErrorHandler(responseErrorHandler)
 			.build();
 

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeVideoAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeVideoAutoConfiguration.java
@@ -63,7 +63,7 @@ public class DashScopeVideoAutoConfiguration {
 		var videoApi = DashScopeVideoApi.builder()
 			.apiKey(resolved.apiKey())
 			.baseUrl(resolved.baseUrl())
-			.restClientBuilder(restClientBuilderProvider.getIfAvailable())
+			.restClientBuilder(restClientBuilderProvider.getIfAvailable(RestClient::builder))
 			.responseErrorHandler(responseErrorHandler)
 			.build();
 


### PR DESCRIPTION
## Summary
* The ObjectProvider<RestClient.Builder> should create a default RestClient.Builder if one is not auto-configured.

## Changes
* DashScopeImageAutoConfiguration#dashScopeImageModel
* DashScopeVideoAutoConfiguration#dashScopeVideoModel

## Why
* If a default RestClient.Builder is not created, using `spring-boot-starter-webflux` will throw an `IllegalArgumentException` with the message: "restClientBuilder cannot be null".