### PR TITLE
feat(mcp): 优化 Nacos MCP Registry 注册 MCP Server 时的 IP 和端口处理

### DIFF
--- a/mcp/spring-ai-alibaba-mcp-common/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpProperties.java
+++ b/mcp/spring-ai-alibaba-mcp-common/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpProperties.java
@@ -68,6 +68,8 @@ public class NacosMcpProperties {
 	String endpoint;
 
 	String ip;
+	
+	int port = -1;
 
 	@Autowired
 	@JsonIgnore
@@ -120,7 +122,15 @@ public class NacosMcpProperties {
 	public void setIp(String ip) {
 		this.ip = ip;
 	}
-
+	
+	public int getPort() {
+		return port;
+	}
+	
+	public void setPort(int port) {
+		this.port = port;
+	}
+	
 	public String getEndpoint() {
 		return endpoint;
 	}
@@ -139,8 +149,22 @@ public class NacosMcpProperties {
 
 	@PostConstruct
 	public void init() throws Exception {
-		if (StringUtils.isEmpty(this.ip)) {
+		
+		String  ipFromEnv = environment.getProperty("NACOS_MCP_SERVER_ENDPOINT","");
+		
+		if(!StringUtils.isEmpty(ipFromEnv)){
+			this.ip = ipFromEnv;
+		} else if (StringUtils.isEmpty(this.ip)) {
 			this.ip = NetUtils.localIp();
+		}
+		
+		String portFromEnv = environment.getProperty("NACOS_MCP_SERVER_PORT","");
+		if (!StringUtils.isEmpty(portFromEnv)) {
+			try {
+				this.port = Integer.parseInt(portFromEnv);
+			} catch (NumberFormatException e) {
+				log.warn("Invalid port value from NACOS_MCP_SERVER_PORT: {}", portFromEnv);
+			}
 		}
 	}
 

--- a/mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/register/NacosMcpRegister.java
+++ b/mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/register/NacosMcpRegister.java
@@ -376,7 +376,10 @@ public class NacosMcpRegister implements ApplicationListener<WebServerInitialize
 					return;
 				}
 			}
-			int port = event.getWebServer().getPort();
+			int port = this.nacosMcpProperties.getPort();
+			if (this.nacosMcpProperties.getPort() < 0 || this.nacosMcpProperties.getPort() > 65535) {
+				port = event.getWebServer().getPort();
+			}
 			Instance instance = new Instance();
 			instance.setIp(this.nacosMcpProperties.getIp());
 			instance.setPort(port);

--- a/mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/register/NacosStatelessMcpRegister.java
+++ b/mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/register/NacosStatelessMcpRegister.java
@@ -370,7 +370,10 @@ public class NacosStatelessMcpRegister implements ApplicationListener<WebServerI
                     return;
                 }
             }
-            int port = event.getWebServer().getPort();
+            int port = this.nacosMcpProperties.getPort();
+            if (this.nacosMcpProperties.getPort() < 0 || this.nacosMcpProperties.getPort() > 65535) {
+                port = event.getWebServer().getPort();
+            }
             Instance instance = new Instance();
             instance.setIp(this.nacosMcpProperties.getIp());
             instance.setPort(port);


### PR DESCRIPTION
- 在 NacosMcpProperties 中添加 port 属性，用于指定服务端口
- 优先使用环境变量中的 NACOS_MCP_SERVER_ENDPOINT 和 NACOS_MCP_SERVER_PORT
- 在 NacosMcpRegister 和 NacosStatelessMcpRegister 中使用配置的端口
- 如果配置的端口无效或未指定，则使用应用实际端口

Change-Id: Ibfcfb198b4f0b4792147395f3e01ee85c4076f56