### PR TITLE
feat(mcp): support lazy init for streamable mcp client

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-mcp-distributed/pom.xml
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-mcp-distributed/pom.xml
@@ -62,6 +62,12 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-mcp-distributed/src/main/java/com/alibaba/cloud/ai/autoconfigure/mcp/discovery/client/NacosMcpStreamableClientAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-mcp-distributed/src/main/java/com/alibaba/cloud/ai/autoconfigure/mcp/discovery/client/NacosMcpStreamableClientAutoConfiguration.java
@@ -49,7 +49,8 @@ public class NacosMcpStreamableClientAutoConfiguration {
             matchIfMissing = true)
     public List<DistributedSyncMcpClient> streamableWebFluxDistributedSyncClients(
             ObjectProvider<Map<String, NacosMcpOperationService>> nacosMcpOperationServiceMapProvider,
-            NacosMcpStreamableClientProperties nacosMcpStreamableClientProperties, ApplicationContext applicationContext) {
+            NacosMcpStreamableClientProperties nacosMcpStreamableClientProperties,
+            ApplicationContext applicationContext, NacosMcpClientProperties nacosMcpClientProperties) {
         Map<String, NacosMcpOperationService> nacosMcpOperationServiceMap = nacosMcpOperationServiceMapProvider.getObject();
         List<DistributedSyncMcpClient> clients = new ArrayList<>();
 
@@ -59,11 +60,11 @@ public class NacosMcpStreamableClientAutoConfiguration {
                     .version(nacosSseParameters.version())
                     .nacosMcpOperationService(nacosMcpOperationServiceMap.get(name))
                     .applicationContext(applicationContext)
+                    .lazyInit(nacosMcpClientProperties.isLazyInit())
                     .build();
             client.init();
             client.subscribe();
             clients.add(client);
-
         });
         return clients;
     }
@@ -73,7 +74,8 @@ public class NacosMcpStreamableClientAutoConfiguration {
             matchIfMissing = true)
     public List<DistributedAsyncMcpClient> streamableWebFluxDistributedAsyncClients(
             ObjectProvider<Map<String, NacosMcpOperationService>> nacosMcpOperationServiceMapProvider,
-            NacosMcpStreamableClientProperties nacosMcpStreamableClientProperties, ApplicationContext applicationContext) {
+            NacosMcpStreamableClientProperties nacosMcpStreamableClientProperties,
+            ApplicationContext applicationContext, NacosMcpClientProperties nacosMcpClientProperties) {
         Map<String, NacosMcpOperationService> nacosMcpOperationServiceMap = nacosMcpOperationServiceMapProvider.getObject();
         List<DistributedAsyncMcpClient> clients = new ArrayList<>();
 
@@ -83,10 +85,10 @@ public class NacosMcpStreamableClientAutoConfiguration {
                     .version(nacosSseParameters.version())
                     .nacosMcpOperationService(nacosMcpOperationServiceMap.get(name))
                     .applicationContext(applicationContext)
+                    .lazyInit(nacosMcpClientProperties.isLazyInit())
                     .build();
             client.init();
             client.subscribe();
-
             clients.add(client);
         });
         return clients;

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-mcp-distributed/src/test/java/com/alibaba/cloud/ai/autoconfigure/mcp/discovery/client/NacosMcpClientPropertiesTests.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-mcp-distributed/src/test/java/com/alibaba/cloud/ai/autoconfigure/mcp/discovery/client/NacosMcpClientPropertiesTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.autoconfigure.mcp.discovery.client;
+
+import com.alibaba.cloud.ai.mcp.nacos.NacosMcpClientProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NacosMcpClientPropertiesTests {
+
+    @Test
+    void shouldBindLazyInitProperty() {
+        ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(NacosMcpAutoConfiguration.class))
+                .withPropertyValues("spring.ai.alibaba.mcp.nacos.client.lazy-init=true");
+
+        contextRunner.run(context -> {
+            NacosMcpClientProperties properties = context.getBean(NacosMcpClientProperties.class);
+
+            assertThat(properties.isLazyInit()).isTrue();
+        });
+    }
+
+}
+

--- a/mcp/spring-ai-alibaba-mcp-common/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpClientProperties.java
+++ b/mcp/spring-ai-alibaba-mcp-common/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpClientProperties.java
@@ -32,9 +32,19 @@ public class NacosMcpClientProperties {
 
     private final Map<String, NacosConfig> configs = new HashMap<>();
 
+	private boolean lazyInit = false;
+
     public Map<String, NacosConfig> getConfigs() {
         return configs;
     }
+
+	public boolean isLazyInit() {
+		return lazyInit;
+	}
+
+	public void setLazyInit(boolean lazyInit) {
+		this.lazyInit = lazyInit;
+	}
 
     public record NacosConfig(String namespace, String serverAddr, String username, String password, String accessKey, String secretKey,
                                      String endpoint) {

--- a/mcp/spring-ai-alibaba-mcp-distributed/pom.xml
+++ b/mcp/spring-ai-alibaba-mcp-distributed/pom.xml
@@ -70,6 +70,12 @@
             <version>${mcp-spring.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/mcp/spring-ai-alibaba-mcp-distributed/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/streamable/StreamWebFluxDistributedSyncMcpClient.java
+++ b/mcp/spring-ai-alibaba-mcp-distributed/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/streamable/StreamWebFluxDistributedSyncMcpClient.java
@@ -73,17 +73,20 @@ public class StreamWebFluxDistributedSyncMcpClient implements DistributedSyncMcp
 
     private final McpJsonMapper mcpJsonMapper;
 
+    private final boolean lazyInit;
+
     private final AtomicInteger index = new AtomicInteger(0);
 
-    private Map<String, McpSyncClient> keyToClientMap;
+    private Map<String, McpSyncClient> keyToClientMap = new ConcurrentHashMap<>();
 
     private NacosMcpServerEndpoint serverEndpoint;
 
     // Link Tracking Filters
     private final ExchangeFilterFunction traceFilter;
 
-    public StreamWebFluxDistributedSyncMcpClient(String serverName, String version,
-                                              NacosMcpOperationService nacosMcpOperationService, ApplicationContext applicationContext) {
+    public StreamWebFluxDistributedSyncMcpClient(String serverName, String version, 
+                                                 NacosMcpOperationService nacosMcpOperationService, 
+                                                 ApplicationContext applicationContext, boolean lazyInit) {
         Assert.notNull(serverName, "serviceName cannot be null");
         Assert.notNull(version, "version cannot be null");
         Assert.notNull(nacosMcpOperationService, "nacosMcpOperationService cannot be null");
@@ -92,24 +95,7 @@ public class StreamWebFluxDistributedSyncMcpClient implements DistributedSyncMcp
         this.serverName = serverName;
         this.version = version;
         this.nacosMcpOperationService = nacosMcpOperationService;
-
-        try {
-            this.serverEndpoint = this.nacosMcpOperationService.getServerEndpoint(serverName, version);
-            if (this.serverEndpoint == null) {
-                throw new NacosException(NacosException.NOT_FOUND,
-                        String.format("[Nacos Mcp Sync Client] Can not find mcp server from nacos: %s, version:%s",
-                                serverName, version));
-            }
-            if (!StringUtils.equals(serverEndpoint.getProtocol(), AiConstants.Mcp.MCP_PROTOCOL_STREAMABLE)) {
-                throw new RuntimeException(
-                        String.format("[Nacos Mcp Sync Client] Protocol of mcp server:%s, version :%s must be streamable",
-                                serverName, version));
-            }
-        } catch (NacosException e) {
-            throw new RuntimeException(String.format(
-                    "[Nacos Mcp Sync Client] Failed to get endpoints for Mcp Server from nacos: %s, version:%s",
-                    serverName, version), e);
-        }
+        this.lazyInit = lazyInit;
 
         commonProperties = applicationContext.getBean(McpClientCommonProperties.class);
         mcpSyncClientConfigurer = applicationContext.getBean(McpSyncClientConfigurer.class);
@@ -130,12 +116,19 @@ public class StreamWebFluxDistributedSyncMcpClient implements DistributedSyncMcp
 
     public Map<String, McpSyncClient> init() {
         keyToClientMap = new ConcurrentHashMap<>();
+        boolean initialized = initServerEndpoint(serverName, version);
+        if (!initialized) {
+            logger.info("[Nacos Mcp Sync Client] No MCP server endpoint found during init. serverName: {}, version: {}",
+                    serverName, version);
+            return keyToClientMap;
+        }
         for (McpEndpointInfo mcpEndpointInfo : serverEndpoint.getMcpEndpointInfoList()) {
             updateByAddEndpoint(mcpEndpointInfo, serverEndpoint.getExportPath());
         }
         logger.info("[Nacos Mcp Sync Client] McpSyncClient init, serverName: {}, version: {}, endpoint: {}", serverName,
                 version, serverEndpoint);
-        return keyToClientMap;    }
+        return keyToClientMap;
+    }
 
     public void subscribe() {
         String serverNameAndVersion = this.serverName + "::" + this.version;
@@ -217,6 +210,13 @@ public class StreamWebFluxDistributedSyncMcpClient implements DistributedSyncMcp
     }
 
     private void updateClientList(NacosMcpServerEndpoint newServerEndpoint) {
+        if (this.serverEndpoint == null) {
+            for (McpEndpointInfo mcpEndpointInfo : newServerEndpoint.getMcpEndpointInfoList()) {
+                updateByAddEndpoint(mcpEndpointInfo, newServerEndpoint.getExportPath());
+            }
+            this.serverEndpoint = newServerEndpoint;
+            return;
+        }
         if (!StringUtils.equals(this.serverEndpoint.getExportPath(), newServerEndpoint.getExportPath())
                 || !StringUtils.equals(this.serverEndpoint.getVersion(), newServerEndpoint.getVersion())) {
             logger.info(
@@ -253,6 +253,33 @@ public class StreamWebFluxDistributedSyncMcpClient implements DistributedSyncMcp
             }
         }
         this.serverEndpoint = newServerEndpoint;
+    }
+
+    protected boolean initServerEndpoint(String serverName, String version) {
+        try {
+            this.serverEndpoint = this.nacosMcpOperationService.getServerEndpoint(serverName, version);
+            if (this.serverEndpoint == null) {
+                throw new NacosException(NacosException.NOT_FOUND,
+                        String.format("[Nacos Mcp Sync Client] Can not find mcp server from nacos: %s, version:%s",
+                                serverName, version));
+            }
+            if (!StringUtils.equals(serverEndpoint.getProtocol(), AiConstants.Mcp.MCP_PROTOCOL_STREAMABLE)) {
+                throw new RuntimeException(
+                        String.format("[Nacos Mcp Sync Client] Protocol of mcp server:%s, version :%s must be streamable",
+                                serverName, version));
+            }
+            return true;
+        } catch (NacosException e) {
+            if (lazyInit) {
+                logger.warn("[Nacos Mcp Sync Client] Failed to get endpoints for Mcp Server from nacos: {}, " +
+                        "version:{}", serverName, version, e);
+                this.serverEndpoint = null;
+                return false;
+            }
+            throw new RuntimeException(String.format(
+                    "[Nacos Mcp Sync Client] Failed to get endpoints for Mcp Server from nacos: %s, version:%s",
+                    serverName, version), e);
+        }
     }
 
     private void updateAll(NacosMcpServerEndpoint newServerEndpoint) {
@@ -438,6 +465,8 @@ public class StreamWebFluxDistributedSyncMcpClient implements DistributedSyncMcp
 
         private ApplicationContext applicationContext;
 
+        private boolean lazyInit;
+
         public Builder serverName(String serverName) {
             this.serverName = serverName;
             return this;
@@ -458,9 +487,14 @@ public class StreamWebFluxDistributedSyncMcpClient implements DistributedSyncMcp
             return this;
         }
 
+        public Builder lazyInit(boolean lazyInit) {
+            this.lazyInit = lazyInit;
+            return this;
+        }
+
         public StreamWebFluxDistributedSyncMcpClient build() {
-            return new StreamWebFluxDistributedSyncMcpClient(this.serverName, this.version, this.nacosMcpOperationService,
-                    this.applicationContext);
+            return new StreamWebFluxDistributedSyncMcpClient(this.serverName, this.version, 
+                this.nacosMcpOperationService, this.applicationContext, this.lazyInit);
         }
 
     }

--- a/mcp/spring-ai-alibaba-mcp-distributed/src/test/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/streamable/StreamWebFluxDistributedAsyncMcpClientIntegrationTests.java
+++ b/mcp/spring-ai-alibaba-mcp-distributed/src/test/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/streamable/StreamWebFluxDistributedAsyncMcpClientIntegrationTests.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.mcp.discovery.client.transport.streamable;
+
+import com.alibaba.cloud.ai.mcp.nacos.service.NacosMcpOperationService;
+import com.alibaba.cloud.ai.mcp.nacos.service.NacosMcpSubscriber;
+import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.ai.constant.AiConstants;
+import com.alibaba.nacos.api.ai.model.mcp.McpEndpointInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerRemoteServiceConfig;
+import com.alibaba.nacos.api.ai.model.mcp.McpServiceRef;
+import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
+import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.mcp.client.common.autoconfigure.configurer.McpAsyncClientConfigurer;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The current integration test requires dependency on Nacos server 3.1.
+ * If you have a running Nacos Server locally, you can remove @Disabled and run it.
+ * TODO: Set up the Nacos server for integration testing in GitHub Actions.
+ */
+@Disabled
+class StreamWebFluxDistributedAsyncMcpClientIntegrationTests {
+
+    private static final String NACOS_HOST = "localhost";
+
+    private static final int NACOS_PORT = 8848;
+
+    private static final String NACOS_USERNAME = "nacos";
+
+    private static final String NACOS_PASSWORD = "nacos";
+
+    private static final String DEFAULT_NAMESPACE = "public";
+
+    private static final String DEFAULT_GROUP = "DEFAULT_GROUP";
+
+    private final ApplicationContextRunner springContext = new ApplicationContextRunner()
+            .withUserConfiguration(TestClientConfiguration.class);
+
+    private final Map<String, NacosMcpOperationService> operationServiceCache = new HashMap<>();
+
+    @Test
+    void lazyInit_shouldStartWhenServiceNeverRegistered() {
+        assertThat(isNacosReachable()).isTrue().as("Nacos Server is required for this test");
+
+        TestMcpServerSpec spec = TestMcpServerSpec.create("svc-a");
+        boolean lazyInit = true;
+
+        springContext.run(context -> {
+            StreamWebFluxDistributedAsyncMcpClient client = createClient(context, spec, lazyInit);
+            assertThat(client.getMcpAsyncClientList()).isEmpty();
+            assertThat(client.getNacosMcpServerEndpoint()).isNull();
+        });
+    }
+
+    @Test
+    void lazyInit_shouldStartWhenServiceRegisteredWithoutInstances() throws Exception {
+        assertThat(isNacosReachable()).isTrue().as("Nacos Server is required for this test");
+
+        TestMcpServerSpec spec = TestMcpServerSpec.create("svc-b");
+        NacosMcpOperationService operationService = createOperationService();
+        createMcpServer(operationService, spec);
+        Instance instance = registerInstance(operationService, spec);
+        waitAndAssertEndpointsSize(operationService, spec, 1);
+        deregisterInstance(operationService, instance, spec);
+        waitAndAssertEndpointsSize(operationService, spec, 0);
+
+        boolean lazyInit = true;
+        springContext.run(context -> {
+            StreamWebFluxDistributedAsyncMcpClient client = createClient(context, spec, lazyInit);
+            assertThat(client.getMcpAsyncClientList()).isEmpty();
+            assertThat(client.getNacosMcpServerEndpoint()).isNotNull();
+        });
+    }
+
+    @Test
+    void lazyInit_shouldDetectInstanceAfterRegistration() {
+        assertThat(isNacosReachable()).isTrue().as("Nacos Server is required for this test");
+
+        TestMcpServerSpec spec = TestMcpServerSpec.create("svc-c");
+        boolean lazyInit = true;
+
+        springContext.run(context -> {
+            StreamWebFluxDistributedAsyncMcpClient client = createClient(context, spec, lazyInit);
+            assertThat(client.getMcpAsyncClientList()).isEmpty();
+
+            NacosMcpOperationService operationService = getOperationService(spec.configName());
+            createMcpServer(operationService, spec);
+            Instance instance = registerInstance(operationService, spec);
+
+            waitAndAssertEndpointsSize(operationService, spec, 1);
+            forceTriggerSubscribe(operationService, spec);
+            waitAndAssertClientSize(client, 1);
+
+            deregisterInstance(operationService, instance, spec);
+        });
+    }
+
+    @Test
+    void lazyInit_shouldHandleInstanceRemoval() {
+        assertThat(isNacosReachable()).isTrue().as("Nacos Server is required for this test");
+
+        TestMcpServerSpec spec = TestMcpServerSpec.create("svc-d");
+        boolean lazyInit = true;
+
+        springContext.run(context -> {
+            StreamWebFluxDistributedAsyncMcpClient client = createClient(context, spec, lazyInit);
+            NacosMcpOperationService operationService = getOperationService(spec.configName());
+
+            createMcpServer(operationService, spec);
+            Instance instance = registerInstance(operationService, spec);
+            waitAndAssertEndpointsSize(operationService, spec, 1);
+            forceTriggerSubscribe(operationService, spec);
+            waitAndAssertClientSize(client, 1);
+
+            deregisterInstance(operationService, instance, spec);
+            waitAndAssertEndpointsSize(operationService, spec, 0);
+            forceTriggerSubscribe(operationService, spec);
+            waitAndAssertClientSize(client, 0);
+        });
+    }
+
+    @Test
+    void nonLazy_shouldFailWhenServiceMissing() {
+        assertThat(isNacosReachable()).isTrue().as("Nacos Server is required for this test");
+
+        TestMcpServerSpec spec = TestMcpServerSpec.create("svc-e-new");
+        boolean lazyInit = false;
+
+        springContext.run(context -> {
+            try {
+                createClient(context, spec, lazyInit);
+                throw new AssertionError("Should have thrown exception");
+            } catch (RuntimeException e) {
+                assertThat(e).hasMessageContaining("Failed to get endpoints");
+            }
+        });
+    }
+
+    @Test
+    void nonLazy_shouldStartWhenServiceRegisteredButNoInstances() throws Exception {
+        assertThat(isNacosReachable()).isTrue().as("Nacos Server is required for this test");
+
+        TestMcpServerSpec spec = TestMcpServerSpec.create("svc-e-known");
+        NacosMcpOperationService operationService = createOperationService();
+        createMcpServer(operationService, spec);
+        boolean lazyInit = false;
+
+        springContext.run(context -> {
+            StreamWebFluxDistributedAsyncMcpClient client = createClient(context, spec, lazyInit);
+            assertThat(client).isNotNull();
+            assertThat(client.getMcpAsyncClientList()).isEmpty();
+        });
+    }
+
+    private StreamWebFluxDistributedAsyncMcpClient createClient(ConfigurableApplicationContext context,
+            TestMcpServerSpec spec, boolean lazyInit) {
+        NacosMcpOperationService operationService = getOperationService(spec.configName());
+        StreamWebFluxDistributedAsyncMcpClient client = StreamWebFluxDistributedAsyncMcpClient.builder()
+                .serverName(spec.serverName())
+                .version(spec.version())
+                .nacosMcpOperationService(operationService)
+                .applicationContext(context)
+                .lazyInit(lazyInit)
+                .build();
+        client.init();
+        client.subscribe();
+        return client;
+    }
+
+    private NacosMcpOperationService getOperationService(String configName) {
+        return operationServiceCache.computeIfAbsent(configName, key -> {
+            try {
+                Properties properties = new Properties();
+                properties.put(PropertyKeyConst.SERVER_ADDR, NACOS_HOST + ":" + NACOS_PORT);
+                properties.put(PropertyKeyConst.NAMESPACE, DEFAULT_NAMESPACE);
+                properties.put(PropertyKeyConst.USERNAME, NACOS_USERNAME);
+                properties.put(PropertyKeyConst.PASSWORD, NACOS_PASSWORD);
+                return new NacosMcpOperationService(properties);
+            } catch (NacosException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private boolean isNacosReachable() {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(NACOS_HOST, NACOS_PORT), 500);
+            return true;
+        } catch (IOException ignored) {
+            return false;
+        }
+    }
+
+    private NacosMcpOperationService createOperationService() throws NacosException {
+        Properties properties = new Properties();
+        properties.put(PropertyKeyConst.SERVER_ADDR, NACOS_HOST + ":" + NACOS_PORT);
+        properties.put(PropertyKeyConst.NAMESPACE, DEFAULT_NAMESPACE);
+        properties.put(PropertyKeyConst.USERNAME, NACOS_USERNAME);
+        properties.put(PropertyKeyConst.PASSWORD, NACOS_PASSWORD);
+        return new NacosMcpOperationService(properties);
+    }
+
+    private void createMcpServer(NacosMcpOperationService operationService, TestMcpServerSpec spec)
+            throws NacosException {
+        McpServerBasicInfo basicInfo = new McpServerBasicInfo();
+        basicInfo.setName(spec.serverName());
+        basicInfo.setDescription(spec.serverName() + " integration test");
+
+        ServerVersionDetail versionDetail = new ServerVersionDetail();
+        versionDetail.setVersion(spec.version());
+        basicInfo.setVersionDetail(versionDetail);
+        basicInfo.setProtocol(AiConstants.Mcp.MCP_PROTOCOL_STREAMABLE);
+        basicInfo.setFrontProtocol(AiConstants.Mcp.MCP_PROTOCOL_STREAMABLE);
+
+        McpServiceRef serviceRef = new McpServiceRef();
+        serviceRef.setServiceName(spec.nacosServiceName());
+        serviceRef.setGroupName(DEFAULT_GROUP);
+        serviceRef.setNamespaceId(DEFAULT_NAMESPACE);
+
+        McpServerRemoteServiceConfig remoteConfig = new McpServerRemoteServiceConfig();
+        remoteConfig.setServiceRef(serviceRef);
+        remoteConfig.setExportPath(spec.exportPath());
+        basicInfo.setRemoteServerConfig(remoteConfig);
+
+        McpEndpointSpec endpointSpec = new McpEndpointSpec();
+        endpointSpec.setType(AiConstants.Mcp.MCP_ENDPOINT_TYPE_REF);
+        Map<String, String> data = new HashMap<>();
+        data.put("serviceName", spec.nacosServiceName());
+        data.put("groupName", DEFAULT_GROUP);
+        endpointSpec.setData(data);
+
+        McpToolSpecification toolSpecification = new McpToolSpecification();
+        toolSpecification.setTools(new ArrayList<>());
+
+        operationService.createMcpServer(spec.serverName(), basicInfo, toolSpecification, endpointSpec);
+    }
+
+    private Instance registerInstance(NacosMcpOperationService op, TestMcpServerSpec spec) throws NacosException {
+        Instance instance = new Instance();
+        instance.setIp("127.0.0.1");
+        instance.setPort(findAvailablePort());
+        instance.setEphemeral(true);
+        instance.setHealthy(true);
+        instance.setWeight(1.0);
+        op.registerService(spec.nacosServiceName(), DEFAULT_GROUP, instance);
+        return instance;
+    }
+
+    private NamingService extractNamingService(NacosMcpOperationService op)
+            throws NoSuchFieldException, IllegalAccessException {
+        Field field = NacosMcpOperationService.class.getDeclaredField("namingService");
+        field.setAccessible(true);
+        return (NamingService) field.get(op);
+    }
+
+    private void deregisterInstance(NacosMcpOperationService op, Instance instance, TestMcpServerSpec spec) {
+        try {
+            NamingService namingService = extractNamingService(op);
+            namingService.deregisterInstance(spec.nacosServiceName(), DEFAULT_GROUP, instance.getIp(),
+                    instance.getPort());
+        } catch (Exception ignored) {
+        }
+    }
+
+    private void waitAndAssertEndpointsSize(NacosMcpOperationService op, TestMcpServerSpec spec, int expected)
+            throws NacosException {
+        long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+        while (System.nanoTime() < deadline) {
+            McpServerDetailInfo detail = op.getServerDetail(spec.serverName(), spec.version());
+            if (detail != null) {
+                List<McpEndpointInfo> endpoints = detail.getBackendEndpoints();
+                int size = endpoints == null ? 0 : endpoints.size();
+                if (size == expected) {
+                    return;
+                }
+            }
+            sleepBriefly();
+        }
+        throw new AssertionError("Timed out waiting for " + expected + " endpoints for " + spec.serverName());
+    }
+
+    private void forceTriggerSubscribe(NacosMcpOperationService op, TestMcpServerSpec spec) throws Exception {
+        Field field = NacosMcpOperationService.class.getDeclaredField("subscribers");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, List<NacosMcpSubscriber>> subscribers = (Map<String, List<NacosMcpSubscriber>>) field.get(op);
+        if (subscribers == null) {
+            return;
+        }
+        List<NacosMcpSubscriber> subscriberList = subscribers.get(spec.serverName() + "::" + spec.version());
+        if (subscriberList == null || subscriberList.isEmpty()) {
+            return;
+        }
+        McpServerDetailInfo detail = op.getServerDetail(spec.serverName(), spec.version());
+        if (detail == null) {
+            return;
+        }
+        subscriberList.forEach(subscriber -> subscriber.receive(detail));
+    }
+
+    private void waitAndAssertClientSize(StreamWebFluxDistributedAsyncMcpClient client, int expectedClientSize) {
+        long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+        while (System.nanoTime() < deadline) {
+            int actualClientSize = client.getMcpAsyncClientList().size();
+            if (actualClientSize == expectedClientSize) {
+                return;
+            }
+            sleepBriefly();
+        }
+        throw new AssertionError("Client did not reach expected size within " + Duration.ofSeconds(10));
+    }
+
+    private void sleepBriefly() {
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private int findAvailablePort() {
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            return serverSocket.getLocalPort();
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to allocate port", ex);
+        }
+    }
+
+    private record TestMcpServerSpec(String configName, String serverName, String version, String nacosServiceName,
+            String exportPath) {
+        public static TestMcpServerSpec create(String prefix) {
+            String id = prefix + "-" + UUID.randomUUID().toString().replace("-", "");
+            return new TestMcpServerSpec("cfg-" + id, "mcp-" + id, "1.0.0", "svc-" + id, "/mcp-" + id);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class TestClientConfiguration {
+
+        @Bean
+        McpClientCommonProperties mcpClientCommonProperties() {
+            McpClientCommonProperties properties = new McpClientCommonProperties();
+            properties.setEnabled(true);
+            properties.setName("integration-client");
+            properties.setVersion("1.0.0");
+            properties.setInitialized(false);
+            return properties;
+        }
+
+        @Bean
+        McpAsyncClientConfigurer mcpAsyncClientConfigurer() {
+            return new McpAsyncClientConfigurer(List.of());
+        }
+
+        @Bean
+        WebClient.Builder webClientBuilder() {
+            return WebClient.builder();
+        }
+
+        @Bean
+        ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+    }
+}

--- a/mcp/spring-ai-alibaba-mcp-distributed/src/test/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/streamable/StreamWebFluxDistributedSyncMcpClientIntegrationTests.java
+++ b/mcp/spring-ai-alibaba-mcp-distributed/src/test/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/streamable/StreamWebFluxDistributedSyncMcpClientIntegrationTests.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.mcp.discovery.client.transport.streamable;
+
+import com.alibaba.cloud.ai.mcp.nacos.service.NacosMcpOperationService;
+import com.alibaba.cloud.ai.mcp.nacos.service.NacosMcpSubscriber;
+import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.ai.constant.AiConstants;
+import com.alibaba.nacos.api.ai.model.mcp.McpEndpointInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerRemoteServiceConfig;
+import com.alibaba.nacos.api.ai.model.mcp.McpServiceRef;
+import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
+import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.mcp.client.common.autoconfigure.configurer.McpSyncClientConfigurer;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The current integration test requires dependency on Nacos server 3.1.
+ * If you have a running Nacos Server locally, you can remove @Disabled and run it.
+ * TODO: Set up the Nacos server for integration testing in GitHub Actions.
+ */
+@Disabled
+class StreamWebFluxDistributedSyncMcpClientIntegrationTests {
+
+    private static final String NACOS_HOST = "localhost";
+
+    private static final int NACOS_PORT = 8848;
+
+    private static final String NACOS_USERNAME = "nacos";
+
+    private static final String NACOS_PASSWORD = "nacos";
+
+    private static final String DEFAULT_NAMESPACE = "public";
+
+    private static final String DEFAULT_GROUP = "DEFAULT_GROUP";
+
+    private final ApplicationContextRunner springContext = new ApplicationContextRunner()
+            .withUserConfiguration(TestClientConfiguration.class);
+
+    private final Map<String, NacosMcpOperationService> operationServiceCache = new HashMap<>();
+
+    @Test
+    void lazyInit_shouldStartWhenServiceNeverRegistered() {
+        assertThat(isNacosReachable()).isTrue().as("Nacos Server is required for this test");
+
+        TestMcpServerSpec spec = TestMcpServerSpec.create("svc-a");
+        boolean lazyInit = true;
+
+        springContext.run(context -> {
+            StreamWebFluxDistributedSyncMcpClient client = createClient(context, spec, lazyInit);
+            assertThat(client.getMcpSyncClientList()).isEmpty();
+            assertThat(client.getNacosMcpServerEndpoint()).isNull();
+        });
+    }
+
+    @Test
+    void lazyInit_shouldStartWhenServiceRegisteredWithoutInstances() throws Exception {
+        assertThat(isNacosReachable()).isTrue().as("Nacos Server is required for this test");
+
+        TestMcpServerSpec spec = TestMcpServerSpec.create("svc-b");
+        NacosMcpOperationService operationService = createOperationService();
+        createMcpServer(operationService, spec);
+        Instance instance = registerInstance(operationService, spec);
+        waitAndAssertEndpointsSize(operationService, spec, 1);
+        deregisterInstance(operationService, instance, spec);
+        waitAndAssertEndpointsSize(operationService, spec, 0);
+
+        boolean lazyInit = true;
+        springContext.run(context -> {
+            StreamWebFluxDistributedSyncMcpClient client = createClient(context, spec, lazyInit);
+            assertThat(client.getMcpSyncClientList()).isEmpty();
+            assertThat(client.getNacosMcpServerEndpoint()).isNotNull();
+        });
+    }
+
+    @Test
+    void lazyInit_shouldDetectInstanceAfterRegistration() {
+        assertThat(isNacosReachable()).isTrue().as("Nacos Server is required for this test");
+
+        TestMcpServerSpec spec = TestMcpServerSpec.create("svc-c");
+        boolean lazyInit = true;
+
+        springContext.run(context -> {
+            StreamWebFluxDistributedSyncMcpClient client = createClient(context, spec, lazyInit);
+            assertThat(client.getMcpSyncClientList()).isEmpty();
+
+            NacosMcpOperationService operationService = getOperationService(spec.configName());
+            createMcpServer(operationService, spec);
+            Instance instance = registerInstance(operationService, spec);
+
+            waitAndAssertEndpointsSize(operationService, spec, 1);
+            forceTriggerSubscribe(operationService, spec);
+            waitAndAssertClientSize(client, 1);
+
+            deregisterInstance(operationService, instance, spec);
+        });
+    }
+
+    @Test
+    void lazyInit_shouldHandleInstanceRemoval() {
+        assertThat(isNacosReachable()).isTrue().as("Nacos Server is required for this test");
+
+        TestMcpServerSpec spec = TestMcpServerSpec.create("svc-d");
+        boolean lazyInit = true;
+
+        springContext.run(context -> {
+            StreamWebFluxDistributedSyncMcpClient client = createClient(context, spec, lazyInit);
+            NacosMcpOperationService operationService = getOperationService(spec.configName());
+
+            createMcpServer(operationService, spec);
+            Instance instance = registerInstance(operationService, spec);
+            waitAndAssertEndpointsSize(operationService, spec, 1);
+            forceTriggerSubscribe(operationService, spec);
+            waitAndAssertClientSize(client, 1);
+
+            deregisterInstance(operationService, instance, spec);
+            waitAndAssertEndpointsSize(operationService, spec, 0);
+            forceTriggerSubscribe(operationService, spec);
+            waitAndAssertClientSize(client, 0);
+        });
+    }
+
+    @Test
+    void nonLazy_shouldFailWhenServiceMissing() {
+        assertThat(isNacosReachable()).isTrue().as("Nacos Server is required for this test");
+
+        TestMcpServerSpec spec = TestMcpServerSpec.create("svc-e-new");
+        boolean lazyInit = false;
+
+        springContext.run(context -> {
+            try {
+                createClient(context, spec, lazyInit);
+                throw new AssertionError("Should have thrown exception");
+            } catch (RuntimeException e) {
+                assertThat(e).hasMessageContaining("Failed to get endpoints");
+            }
+        });
+    }
+
+    @Test
+    void nonLazy_shouldStartWhenServiceRegisteredButNoInstances() throws Exception {
+        assertThat(isNacosReachable()).isTrue().as("Nacos Server is required for this test");
+
+        TestMcpServerSpec spec = TestMcpServerSpec.create("svc-e-known");
+        NacosMcpOperationService operationService = createOperationService();
+        createMcpServer(operationService, spec);
+        boolean lazyInit = false;
+
+        springContext.run(context -> {
+            StreamWebFluxDistributedSyncMcpClient client = createClient(context, spec, lazyInit);
+            assertThat(client).isNotNull();
+            assertThat(client.getMcpSyncClientList()).isEmpty();
+        });
+    }
+
+    private StreamWebFluxDistributedSyncMcpClient createClient(ConfigurableApplicationContext context,
+            TestMcpServerSpec spec, boolean lazyInit) {
+        NacosMcpOperationService operationService = getOperationService(spec.configName());
+        StreamWebFluxDistributedSyncMcpClient client = StreamWebFluxDistributedSyncMcpClient.builder()
+                .serverName(spec.serverName())
+                .version(spec.version())
+                .nacosMcpOperationService(operationService)
+                .applicationContext(context)
+                .lazyInit(lazyInit)
+                .build();
+        client.init();
+        client.subscribe();
+        return client;
+    }
+
+    private NacosMcpOperationService getOperationService(String configName) {
+        return operationServiceCache.computeIfAbsent(configName, key -> {
+            try {
+                Properties properties = new Properties();
+                properties.put(PropertyKeyConst.SERVER_ADDR, NACOS_HOST + ":" + NACOS_PORT);
+                properties.put(PropertyKeyConst.NAMESPACE, DEFAULT_NAMESPACE);
+                properties.put(PropertyKeyConst.USERNAME, NACOS_USERNAME);
+                properties.put(PropertyKeyConst.PASSWORD, NACOS_PASSWORD);
+                return new NacosMcpOperationService(properties);
+            } catch (NacosException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private boolean isNacosReachable() {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(NACOS_HOST, NACOS_PORT), 500);
+            return true;
+        } catch (IOException ignored) {
+            return false;
+        }
+    }
+
+    private NacosMcpOperationService createOperationService() throws NacosException {
+        Properties properties = new Properties();
+        properties.put(PropertyKeyConst.SERVER_ADDR, NACOS_HOST + ":" + NACOS_PORT);
+        properties.put(PropertyKeyConst.NAMESPACE, DEFAULT_NAMESPACE);
+        properties.put(PropertyKeyConst.USERNAME, NACOS_USERNAME);
+        properties.put(PropertyKeyConst.PASSWORD, NACOS_PASSWORD);
+        return new NacosMcpOperationService(properties);
+    }
+
+    private void createMcpServer(NacosMcpOperationService operationService, TestMcpServerSpec spec)
+            throws NacosException {
+        McpServerBasicInfo basicInfo = new McpServerBasicInfo();
+        basicInfo.setName(spec.serverName());
+        basicInfo.setDescription(spec.serverName() + " integration test");
+
+        ServerVersionDetail versionDetail = new ServerVersionDetail();
+        versionDetail.setVersion(spec.version());
+        basicInfo.setVersionDetail(versionDetail);
+        basicInfo.setProtocol(AiConstants.Mcp.MCP_PROTOCOL_STREAMABLE);
+        basicInfo.setFrontProtocol(AiConstants.Mcp.MCP_PROTOCOL_STREAMABLE);
+
+        McpServiceRef serviceRef = new McpServiceRef();
+        serviceRef.setServiceName(spec.nacosServiceName());
+        serviceRef.setGroupName(DEFAULT_GROUP);
+        serviceRef.setNamespaceId(DEFAULT_NAMESPACE);
+
+        McpServerRemoteServiceConfig remoteConfig = new McpServerRemoteServiceConfig();
+        remoteConfig.setServiceRef(serviceRef);
+        remoteConfig.setExportPath(spec.exportPath());
+        basicInfo.setRemoteServerConfig(remoteConfig);
+
+        McpEndpointSpec endpointSpec = new McpEndpointSpec();
+        endpointSpec.setType(AiConstants.Mcp.MCP_ENDPOINT_TYPE_REF);
+        Map<String, String> data = new HashMap<>();
+        data.put("serviceName", spec.nacosServiceName());
+        data.put("groupName", DEFAULT_GROUP);
+        endpointSpec.setData(data);
+
+        McpToolSpecification toolSpecification = new McpToolSpecification();
+        toolSpecification.setTools(new ArrayList<>());
+
+        operationService.createMcpServer(spec.serverName(), basicInfo, toolSpecification, endpointSpec);
+    }
+
+    private Instance registerInstance(NacosMcpOperationService op, TestMcpServerSpec spec) throws NacosException {
+        Instance instance = new Instance();
+        instance.setIp("127.0.0.1");
+        instance.setPort(findAvailablePort());
+        instance.setEphemeral(true);
+        instance.setHealthy(true);
+        instance.setWeight(1.0);
+        op.registerService(spec.nacosServiceName(), DEFAULT_GROUP, instance);
+        return instance;
+    }
+
+    private NamingService extractNamingService(NacosMcpOperationService op)
+            throws NoSuchFieldException, IllegalAccessException {
+        Field field = NacosMcpOperationService.class.getDeclaredField("namingService");
+        field.setAccessible(true);
+        return (NamingService) field.get(op);
+    }
+
+    private void deregisterInstance(NacosMcpOperationService op, Instance instance, TestMcpServerSpec spec) {
+        try {
+            NamingService namingService = extractNamingService(op);
+            namingService.deregisterInstance(spec.nacosServiceName(), DEFAULT_GROUP, instance.getIp(),
+                    instance.getPort());
+        } catch (Exception ignored) {
+        }
+    }
+
+    private void waitAndAssertEndpointsSize(NacosMcpOperationService op, TestMcpServerSpec spec, int expected)
+            throws NacosException {
+        long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+        while (System.nanoTime() < deadline) {
+            McpServerDetailInfo detail = op.getServerDetail(spec.serverName(), spec.version());
+            if (detail != null) {
+                List<McpEndpointInfo> endpoints = detail.getBackendEndpoints();
+                int size = endpoints == null ? 0 : endpoints.size();
+                if (size == expected) {
+                    return;
+                }
+            }
+            sleepBriefly();
+        }
+        throw new AssertionError("Timed out waiting for " + expected + " endpoints for " + spec.serverName());
+    }
+
+    private void forceTriggerSubscribe(NacosMcpOperationService op, TestMcpServerSpec spec) throws Exception {
+        Field field = NacosMcpOperationService.class.getDeclaredField("subscribers");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, List<NacosMcpSubscriber>> subscribers = (Map<String, List<NacosMcpSubscriber>>) field.get(op);
+        if (subscribers == null) {
+            return;
+        }
+        List<NacosMcpSubscriber> subscriberList = subscribers.get(spec.serverName() + "::" + spec.version());
+        if (subscriberList == null || subscriberList.isEmpty()) {
+            return;
+        }
+        McpServerDetailInfo detail = op.getServerDetail(spec.serverName(), spec.version());
+        if (detail == null) {
+            return;
+        }
+        subscriberList.forEach(subscriber -> subscriber.receive(detail));
+    }
+
+    private void waitAndAssertClientSize(StreamWebFluxDistributedSyncMcpClient client, int expectedClientSize) {
+        long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+        while (System.nanoTime() < deadline) {
+            int actualClientSize = client.getMcpSyncClientList().size();
+            if (actualClientSize == expectedClientSize) {
+                return;
+            }
+            sleepBriefly();
+        }
+        throw new AssertionError("Client did not reach expected size within " + Duration.ofSeconds(10));
+    }
+
+    private void sleepBriefly() {
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private int findAvailablePort() {
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            return serverSocket.getLocalPort();
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to allocate port", ex);
+        }
+    }
+
+    private record TestMcpServerSpec(String configName, String serverName, String version, String nacosServiceName,
+            String exportPath) {
+        public static TestMcpServerSpec create(String prefix) {
+            String id = prefix + "-" + UUID.randomUUID().toString().replace("-", "");
+            return new TestMcpServerSpec("cfg-" + id, "mcp-" + id, "1.0.0", "svc-" + id, "/mcp-" + id);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class TestClientConfiguration {
+
+        @Bean
+        McpClientCommonProperties mcpClientCommonProperties() {
+            McpClientCommonProperties properties = new McpClientCommonProperties();
+            properties.setEnabled(true);
+            properties.setName("integration-client");
+            properties.setVersion("1.0.0");
+            properties.setInitialized(false);
+            return properties;
+        }
+
+        @Bean
+        McpSyncClientConfigurer mcpSyncClientConfigurer() {
+            return new McpSyncClientConfigurer(List.of());
+        }
+
+        @Bean
+        WebClient.Builder webClientBuilder() {
+            return WebClient.builder();
+        }
+
+        @Bean
+        ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+    }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
The mcp-client process can start normally when the mcp-server is not running.

### Does this pull request fix one issue?
Part of #69
I've already implemented lazy init for Streamable HTTP; I'll be implementing lazy init for SSE soon.

### Describe how you did it
Add a lazy init switch to the nacos-mcp-starter configuration. When lazy init is enabled, the mcp-client will ignore whether the mcp-server service or instance exists on Nacos. In this case, the process can start normally, but mcp calls (tools/list , tools/call) before the mcp-server instance registration will fail. When the lazy init switch is disabled, the behavior remains the same as the current behavior.

### Describe how to verify it
I have added some integration test cases that depend on Nacos Server 3.1. 
Currently, I'm using my local Nacos server to run the integration tests, to prevent CI from failing, I added the `@Disabled`  annotation.

### Special notes for reviews
I am trying to understand the execution flow of the current project's GitHub Action, do I need to add the Nacos Server deployment to the current PR?