### PR TITLE
feat(dashscope): Support stream tool call

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelper.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelper.java
@@ -207,7 +207,8 @@ public class DashScopeAiStreamFunctionCallingHelper {
 		if (choice == null) {
 			return false;
 		}
-		return choice.finishReason() == ChatCompletionFinishReason.TOOL_CALLS;
+		return choice.finishReason() == ChatCompletionFinishReason.TOOL_CALLS ||
+				choice.finishReason() == ChatCompletionFinishReason.STOP;
 	}
 
 	/**

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -614,8 +614,7 @@ public class DashScopeApi {
 					throw new DashScopeException("Failed to parse response content: " + content);
 				}
 				return chunk;
-			})
-			.map(chunk -> chunk);
+			});
 
 		if (enableStreamToolCalls) {
 			return baseFlux;

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -548,7 +548,7 @@ public class DashScopeApi {
 	 */
 	public Flux<DashScopeApiSpec.ChatCompletionChunk> chatCompletionStream(DashScopeApiSpec.ChatCompletionRequest chatRequest) {
 
-		return this.chatCompletionStream(chatRequest, null);
+		return this.chatCompletionStream(chatRequest, null, false);
 	}
 
 	/**
@@ -560,12 +560,28 @@ public class DashScopeApi {
 	 * @return Returns a {@link Flux} stream from chat completion chunks.
 	 */
 	public Flux<DashScopeApiSpec.ChatCompletionChunk> chatCompletionStream(DashScopeApiSpec.ChatCompletionRequest chatRequest,
-																		   MultiValueMap<String, String> additionalHttpHeader) {
+															   MultiValueMap<String, String> additionalHttpHeader) {
+
+		return this.chatCompletionStream(chatRequest, additionalHttpHeader, false);
+	}
+
+	/**
+	 * Creates a streaming chat response for the given chat conversation.
+	 * @param chatRequest The chat completion request. Must have the stream property set
+	 * to true.
+	 * @param additionalHttpHeader Optional, additional HTTP headers to be added to the
+	 * request.
+	 * @param enableStreamToolCalls Whether to emit tool call chunks during streaming.
+	 * @return Returns a {@link Flux} stream from chat completion chunks.
+	 */
+	public Flux<DashScopeApiSpec.ChatCompletionChunk> chatCompletionStream(
+			DashScopeApiSpec.ChatCompletionRequest chatRequest,
+			MultiValueMap<String, String> additionalHttpHeader,
+			boolean enableStreamToolCalls) {
 
 		Assert.notNull(chatRequest, "The request body can not be null.");
 		Assert.isTrue(chatRequest.stream(), "Request must set the stream property to true.");
 
-		AtomicBoolean isInsideTool = new AtomicBoolean(false);
 		boolean incrementalOutput = chatRequest.parameters() != null
 				&& chatRequest.parameters().incrementalOutput() != null && chatRequest.parameters().incrementalOutput();
 		DashScopeAiStreamFunctionCallingHelper chunkMerger = new DashScopeAiStreamFunctionCallingHelper(
@@ -576,7 +592,7 @@ public class DashScopeApi {
 			chatCompletionUri = MULTIMODAL_GENERATION_RESTFUL_URL;
 		}
 
-		return this.webClient.post().uri(chatCompletionUri).headers(headers -> {
+		Flux<DashScopeApiSpec.ChatCompletionChunk> baseFlux = this.webClient.post().uri(chatCompletionUri).headers(headers -> {
 			headers.addAll(additionalHttpHeader);
 			// For DashScope stream
 			headers.add(HEADER_SSE, ENABLED);
@@ -599,7 +615,14 @@ public class DashScopeApi {
 				}
 				return chunk;
 			})
-			.map(chunk -> {
+			.map(chunk -> chunk);
+
+		if (enableStreamToolCalls) {
+			return baseFlux;
+		}
+
+		AtomicBoolean isInsideTool = new AtomicBoolean(false);
+		return baseFlux.map(chunk -> {
 				if (chunkMerger.isStreamingToolFunctionCall(chunk)) {
 					isInsideTool.set(true);
 				}

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.dashscope.chat;
 
 import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
 import com.alibaba.cloud.ai.dashscope.metadata.DashScopeAiUsage;
+import com.alibaba.cloud.ai.dashscope.api.DashScopeAiStreamFunctionCallingHelper;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletion;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionChunk;
@@ -87,6 +88,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 /**
@@ -250,15 +253,18 @@ public class DashScopeChatModel implements ChatModel {
     // @formatter:off
 	public Flux<ChatResponse> internalStream(Prompt prompt, ChatResponse previousChatResponse) {
 
-        return Flux.deferContextual(contextView -> {
+		return Flux.deferContextual(contextView -> {
 			ChatCompletionRequest request = createRequest(prompt, true);
+			DashScopeChatOptions requestOptions = (DashScopeChatOptions) prompt.getOptions();
+			boolean enableStreamToolCalls = requestOptions != null
+					&& Boolean.TRUE.equals(requestOptions.getEnableStreamToolCalls());
 
 			Flux<ChatCompletionChunk> completionChunks = this.retryTemplate
                     .execute(ctx -> this.dashscopeApi.chatCompletionStream(
                             request,
-                            getAdditionalHttpHeaders(prompt)
-                    )
-            );
+                            getAdditionalHttpHeaders(prompt),
+							enableStreamToolCalls
+                    ));
 
 			// For chunked responses, only the first chunk contains the choice role.
 			// The rest of the chunks with same ID share the same role.
@@ -281,58 +287,174 @@ public class DashScopeChatModel implements ChatModel {
                     null)
             ).start();
 
-			// Convert the ChatCompletionChunk into a ChatCompletion to be able to reuse
-			// the function call handling logic.
-			Flux<ChatResponse> chatResponse = completionChunks.map(this::chunkToChatCompletion).switchMap(
-                    chatCompletion -> Mono.just(chatCompletion)
-                            .map(chatCompletion2 -> toChatResponse(
-                                    chatCompletion2,
-                                    previousChatResponse,
-                                    request,
-                                    roleMap
-                            ))
-            );
+			Flux<ChatResponse> flux;
+			if (enableStreamToolCalls) {
+				boolean incrementalOutput = request.parameters() != null
+						&& Boolean.TRUE.equals(request.parameters().incrementalOutput());
+				DashScopeAiStreamFunctionCallingHelper toolChunkMerger =
+						new DashScopeAiStreamFunctionCallingHelper(incrementalOutput);
+				AtomicReference<ChatCompletionChunk> pendingToolChunk = new AtomicReference<>(null);
+				AtomicBoolean insideTool = new AtomicBoolean(false);
 
-			Flux<ChatResponse> flux = chatResponse.flatMap(response -> {
-					if (toolExecutionEligibilityPredicate.isToolExecutionRequired(prompt.getOptions(), response)) {
+				Flux<StreamedResponse> streamedResponses = completionChunks.map(chunk -> {
+					ChatCompletionChunk mergedToolChunk = null;
+					boolean toolExecutionReady = false;
+
+					if (toolChunkMerger.isStreamingToolFunctionCall(chunk)) {
+						insideTool.set(true);
+					}
+
+					if (insideTool.get()) {
+						ChatCompletionChunk merged = toolChunkMerger.merge(pendingToolChunk.get(), chunk);
+						pendingToolChunk.set(merged);
+						if (toolChunkMerger.isStreamingToolFunctionCallFinish(chunk)) {
+							insideTool.set(false);
+							toolExecutionReady = true;
+							mergedToolChunk = merged;
+							pendingToolChunk.set(null);
+						}
+					}
+
+					ChatResponse response = toChatResponse(
+							chunkToChatCompletion(chunk),
+							previousChatResponse,
+							request,
+							roleMap
+					);
+					ChatResponse toolExecutionResponse = null;
+					if (toolExecutionReady && mergedToolChunk != null) {
+						toolExecutionResponse = toChatResponse(
+								toolChunkMerger.chunkToChatCompletion(mergedToolChunk),
+								previousChatResponse,
+								request,
+								roleMap
+						);
+					}
+
+					return new StreamedResponse(response, toolExecutionResponse, toolExecutionReady);
+				});
+
+				flux = streamedResponses.flatMap(streamed -> {
+					ChatResponse response = streamed.response();
+					ChatResponse toolExecutionResponse = streamed.toolExecutionResponse();
+
+					if (streamed.toolExecutionReady() && toolExecutionResponse != null
+							&& toolExecutionEligibilityPredicate.isToolExecutionRequired(
+									prompt.getOptions(), toolExecutionResponse)) {
 
 						return Flux.deferContextual((ctx) -> {
-
 							ToolExecutionResult toolExecutionResult;
-
 							try {
 								ToolCallReactiveContextHolder.setContext(ctx);
-								toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, response);
+								toolExecutionResult =
+										this.toolCallingManager.executeToolCalls(prompt, toolExecutionResponse);
 							} finally {
 								ToolCallReactiveContextHolder.clearContext();
 							}
 
+							Flux<ChatResponse> toolResultFlux;
 							if (toolExecutionResult.returnDirect()) {
-
-								// Return tool execution result directly to the client.
-								return Flux.just(ChatResponse.builder().from(response)
+								toolResultFlux = Flux.just(ChatResponse.builder()
+										.from(toolExecutionResponse)
 										.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
 										.build());
 							} else {
-								// Send the tool execution result back to the model.
-								return this.internalStream(
+								toolResultFlux = this.internalStream(
+										new Prompt(
+												toolExecutionResult.conversationHistory(),
+												prompt.getOptions()
+										),
+										toolExecutionResponse
+								);
+							}
+							return Flux.concat(Flux.just(response), toolResultFlux);
+						}).subscribeOn(Schedulers.boundedElastic());
+					}
+
+					return Flux.just(response);
+				});
+			}
+			else {
+				// Convert the ChatCompletionChunk into a ChatCompletion to be able to reuse
+				// the function call handling logic.
+				Flux<ChatResponse> chatResponse = completionChunks.map(this::chunkToChatCompletion).switchMap(
+                        chatCompletion -> Mono.just(chatCompletion)
+                                .map(chatCompletion2 -> toChatResponse(
+                                        chatCompletion2,
+                                        previousChatResponse,
+                                        request,
+                                        roleMap
+                                ))
+                );
+
+				flux = chatResponse.flatMap(response -> {
+						if (toolExecutionEligibilityPredicate.isToolExecutionRequired(prompt.getOptions(), response)) {
+
+							return Flux.deferContextual((ctx) -> {
+
+								ToolExecutionResult toolExecutionResult;
+
+								try {
+									ToolCallReactiveContextHolder.setContext(ctx);
+									toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, response);
+								} finally {
+									ToolCallReactiveContextHolder.clearContext();
+								}
+
+								if (toolExecutionResult.returnDirect()) {
+
+									// Return tool execution result directly to the client.
+									return Flux.just(ChatResponse.builder().from(response)
+											.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
+											.build());
+								} else {
+									// Send the tool execution result back to the model.
+									return this.internalStream(
                                         new Prompt(
                                                 toolExecutionResult.conversationHistory(),
                                                 prompt.getOptions()
                                         ),
-										response
+											response
                                 );
-							}
-						}).subscribeOn(Schedulers.boundedElastic());
-					} else {
-						return Flux.just(response);
-					}
-				}).doOnError(observation::error)
+								}
+							}).subscribeOn(Schedulers.boundedElastic());
+						} else {
+							return Flux.just(response);
+						}
+					});
+			}
+
+			flux = flux.doOnError(observation::error)
 				.doFinally(s -> observation.stop())
 				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
 
 			return new MessageAggregator().aggregate(flux, observationContext::setResponse);
 		});
+	}
+
+	private static final class StreamedResponse {
+		private final ChatResponse response;
+		private final ChatResponse toolExecutionResponse;
+		private final boolean toolExecutionReady;
+
+		private StreamedResponse(ChatResponse response, ChatResponse toolExecutionResponse,
+				boolean toolExecutionReady) {
+			this.response = response;
+			this.toolExecutionResponse = toolExecutionResponse;
+			this.toolExecutionReady = toolExecutionReady;
+		}
+
+		private ChatResponse response() {
+			return response;
+		}
+
+		private ChatResponse toolExecutionResponse() {
+			return toolExecutionResponse;
+		}
+
+		private boolean toolExecutionReady() {
+			return toolExecutionReady;
+		}
 	}
 
 	private static String finishReasonToMetadataValue(DashScopeApiSpec.ChatCompletionFinishReason finishReason) {
@@ -478,6 +600,9 @@ public class DashScopeChatModel implements ChatModel {
 			requestOptions.setInternalToolExecutionEnabled(
 					ModelOptionsUtils.mergeOption(runtimeOptions.getInternalToolExecutionEnabled(),
 							this.defaultOptions.getInternalToolExecutionEnabled()));
+			requestOptions.setEnableStreamToolCalls(
+					ModelOptionsUtils.mergeOption(runtimeOptions.getEnableStreamToolCalls(),
+							this.defaultOptions.getEnableStreamToolCalls()));
 			requestOptions.setToolNames(ToolCallingChatOptions.mergeToolNames(runtimeOptions.getToolNames(),
 					this.defaultOptions.getToolNames()));
 			requestOptions.setToolCallbacks(ToolCallingChatOptions.mergeToolCallbacks(runtimeOptions.getToolCallbacks(),
@@ -488,6 +613,7 @@ public class DashScopeChatModel implements ChatModel {
 		}
 		else {
 			requestOptions.setInternalToolExecutionEnabled(this.defaultOptions.getInternalToolExecutionEnabled());
+			requestOptions.setEnableStreamToolCalls(this.defaultOptions.getEnableStreamToolCalls());
 			requestOptions.setToolNames(this.defaultOptions.getToolNames());
 			requestOptions.setToolCallbacks(this.defaultOptions.getToolCallbacks());
 			requestOptions.setToolContext(this.defaultOptions.getToolContext());

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -315,12 +315,16 @@ public class DashScopeChatModel implements ChatModel {
 						}
 					}
 
-					ChatResponse response = toChatResponse(
-							chunkToChatCompletion(chunk),
-							previousChatResponse,
-							request,
-							roleMap
-					);
+					ChatResponse response = null;
+					boolean isToolCallChunk = insideTool.get() && !toolExecutionReady;
+					if (!isToolCallChunk) {
+						response = toChatResponse(
+								chunkToChatCompletion(chunk),
+								previousChatResponse,
+								request,
+								roleMap
+						);
+					}
 					ChatResponse toolExecutionResponse = null;
 					if (toolExecutionReady && mergedToolChunk != null) {
 						toolExecutionResponse = toChatResponse(
@@ -331,7 +335,7 @@ public class DashScopeChatModel implements ChatModel {
 						);
 					}
 
-					return new StreamedResponse(response, toolExecutionResponse, toolExecutionReady, insideTool.get());
+					return new StreamedResponse(response, toolExecutionResponse, toolExecutionReady, isToolCallChunk);
 				});
 
 				flux = streamedResponses.flatMap(streamed -> {
@@ -369,6 +373,10 @@ public class DashScopeChatModel implements ChatModel {
 							}
 							return Flux.concat(Flux.just(toolExecutionResponse), toolResultFlux);
 						}).subscribeOn(Schedulers.boundedElastic());
+					}
+
+					if (streamed.toolExecutionReady() && toolExecutionResponse != null) {
+						return Flux.just(toolExecutionResponse);
 					}
 
 					if (streamed.isToolCallChunk()) {

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -331,7 +331,7 @@ public class DashScopeChatModel implements ChatModel {
 						);
 					}
 
-					return new StreamedResponse(response, toolExecutionResponse, toolExecutionReady);
+					return new StreamedResponse(response, toolExecutionResponse, toolExecutionReady, insideTool.get());
 				});
 
 				flux = streamedResponses.flatMap(streamed -> {
@@ -367,8 +367,12 @@ public class DashScopeChatModel implements ChatModel {
 										toolExecutionResponse
 								);
 							}
-							return Flux.concat(Flux.just(response), toolResultFlux);
+							return Flux.concat(Flux.just(toolExecutionResponse), toolResultFlux);
 						}).subscribeOn(Schedulers.boundedElastic());
+					}
+
+					if (streamed.isToolCallChunk()) {
+						return Flux.empty();
 					}
 
 					return Flux.just(response);
@@ -436,12 +440,14 @@ public class DashScopeChatModel implements ChatModel {
 		private final ChatResponse response;
 		private final ChatResponse toolExecutionResponse;
 		private final boolean toolExecutionReady;
+		private final boolean isToolCallChunk;
 
 		private StreamedResponse(ChatResponse response, ChatResponse toolExecutionResponse,
-				boolean toolExecutionReady) {
+				boolean toolExecutionReady, boolean isToolCallChunk) {
 			this.response = response;
 			this.toolExecutionResponse = toolExecutionResponse;
 			this.toolExecutionReady = toolExecutionReady;
+			this.isToolCallChunk = isToolCallChunk;
 		}
 
 		private ChatResponse response() {
@@ -454,6 +460,10 @@ public class DashScopeChatModel implements ChatModel {
 
 		private boolean toolExecutionReady() {
 			return toolExecutionReady;
+		}
+
+		private boolean isToolCallChunk() {
+			return isToolCallChunk;
 		}
 	}
 

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
@@ -57,6 +57,12 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
     private Boolean stream;
 
     /**
+     * Whether to emit tool call chunks during streaming responses.
+     */
+    @JsonIgnore
+    private Boolean enableStreamToolCalls = false;
+
+    /**
      * Used to control the degree of randomness and diversity.
      * Specifically, the temperature value smooths the probability distribution
      * of each candidate token during text generation. Higher temperature values
@@ -443,6 +449,14 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
         this.stream = stream;
     }
 
+    public Boolean getEnableStreamToolCalls() {
+        return enableStreamToolCalls;
+    }
+
+    public void setEnableStreamToolCalls(Boolean enableStreamToolCalls) {
+        this.enableStreamToolCalls = enableStreamToolCalls;
+    }
+
     @Override
     public Double getTemperature() {
         return this.temperature;
@@ -819,6 +833,11 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
             return stream(stream);
         }
 
+        public DashScopeChatOptionsBuilder enableStreamToolCalls(Boolean enableStreamToolCalls) {
+            this.options.enableStreamToolCalls = enableStreamToolCalls;
+            return this;
+        }
+
         public DashScopeChatOptionsBuilder toolCallbacks(List<ToolCallback> toolCallbacks) {
             Assert.notNull(toolCallbacks, "toolCallbacks cannot be null");
             Assert.noNullElements(toolCallbacks, "toolCallbacks cannot contain null elements");
@@ -978,6 +997,7 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
                 .stop(fromOptions.stop)
                 .responseFormat(fromOptions.responseFormat)
                 .stream(fromOptions.stream)
+                .enableStreamToolCalls(fromOptions.enableStreamToolCalls)
                 .enableSearch(fromOptions.enableSearch)
                 .incrementalOutput(fromOptions.incrementalOutput)
                 .toolCallbacks(fromOptions.toolCallbacks)
@@ -1008,6 +1028,7 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
         DashScopeChatOptions that = (DashScopeChatOptions) o;
 
         return Objects.equals(this.model, that.model) && Objects.equals(this.stream, that.stream)
+                && Objects.equals(this.enableStreamToolCalls, that.enableStreamToolCalls)
                 && Objects.equals(this.temperature, that.temperature) && Objects.equals(this.seed, that.seed)
                 && Objects.equals(this.topP, that.topP) && Objects.equals(this.topK, that.topK)
                 && Objects.equals(this.stop, that.stop) && Objects.equals(this.enableSearch, that.enableSearch)
@@ -1033,7 +1054,12 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.model, this.stream, this.temperature, this.seed, this.topP, this.topK, this.stop, this.enableSearch, this.responseFormat, this.incrementalOutput, this.repetitionPenalty, this.tools, this.toolChoice, this.vlHighResolutionImages, this.enableThinking, this.thinkingBudget, this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled, this.multiModel, this.searchOptions, this.parallelToolCalls, this.httpHeaders, this.toolContext, this.modalities, this.audio, this.streamOptions, this.extraBody);
+        return Objects.hash(this.model, this.stream, this.enableStreamToolCalls, this.temperature, this.seed, this.topP,
+                this.topK, this.stop, this.enableSearch, this.responseFormat, this.incrementalOutput,
+                this.repetitionPenalty, this.tools, this.toolChoice, this.vlHighResolutionImages, this.enableThinking,
+                this.thinkingBudget, this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled,
+                this.multiModel, this.searchOptions, this.parallelToolCalls, this.httpHeaders, this.toolContext,
+                this.modalities, this.audio, this.streamOptions, this.extraBody);
     }
 
     @Override

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatIT.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatIT.java
@@ -18,16 +18,28 @@ package com.alibaba.cloud.ai.dashscope.chat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
+import com.alibaba.cloud.ai.tool.MockWeatherService;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+import org.springframework.ai.tool.method.MethodToolCallback;
 import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Integration tests for DashScope Chat functionality. These tests will only run if
@@ -123,5 +135,42 @@ class DashScopeChatIT {
 		assertThat(finalResponse).isNotEmpty();
 		System.out.println("Final streaming response: " + finalResponse);
 	}
+
+    @Test
+    @DisplayName("Should stream with tool calls")
+    void testStreamToolCallsWithRealApi() {
+        String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
+        DashScopeApi realApi = DashScopeApi.builder().apiKey(apiKey).build();
+
+        DashScopeChatOptions options = DashScopeChatOptions.builder()
+                .model(TEST_MODEL)
+                .stream(true)
+                .enableStreamToolCalls(true)
+                .internalToolExecutionEnabled(false)
+                .toolChoice(Map.of("type", "function", "function", Map.of("name", "getCurrentWeather")))
+                .toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+                        .description("Get the weather in location")
+                        .inputType(MockWeatherService.Request.class)
+                        .build()))
+                .build();
+
+        DashScopeChatModel realModel = DashScopeChatModel.builder()
+                .dashScopeApi(realApi)
+                .defaultOptions(options)
+                .build();
+
+        Message message = new UserMessage("What's the weather in San Francisco? Use the getCurrentWeather tool.");
+        Prompt prompt = new Prompt(List.of(message), options);
+
+        List<ChatResponse> responses = realModel.stream(prompt).collectList().block();
+
+        assertThat(responses).isNotNull();
+        assertThat(responses).isNotEmpty();
+        assertThat(responses).anySatisfy(response -> {
+            AssistantMessage assistantMessage = response.getResult().getOutput();
+            assertThat(assistantMessage.getToolCalls()).isNotEmpty();
+            assertThat(assistantMessage.getToolCalls().get(0).name()).isEqualTo("getCurrentWeather");
+        });
+    }
 
 }

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatIT.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatIT.java
@@ -31,15 +31,11 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.ai.tool.ToolCallback;
-import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.ai.tool.function.FunctionToolCallback;
-import org.springframework.ai.tool.method.MethodToolCallback;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Integration tests for DashScope Chat functionality. These tests will only run if

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatIT.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatIT.java
@@ -16,6 +16,7 @@
 package com.alibaba.cloud.ai.dashscope.chat;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
 import com.alibaba.cloud.ai.tool.MockWeatherService;
@@ -165,7 +166,17 @@ class DashScopeChatIT {
         assertThat(responses).anySatisfy(response -> {
             AssistantMessage assistantMessage = response.getResult().getOutput();
             assertThat(assistantMessage.getToolCalls()).isNotEmpty();
-            assertThat(assistantMessage.getToolCalls().get(0).name()).isEqualTo("getCurrentWeather");
+
+            var toolCall = assistantMessage.getToolCalls().get(0);
+            assertThat(toolCall.name()).isEqualTo("getCurrentWeather");
+
+            assertThat(toolCall.arguments()).isNotEmpty();
+
+            assertThatCode(() -> {
+                com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+                com.fasterxml.jackson.databind.JsonNode json = mapper.readTree(toolCall.arguments());
+                assertThat(json.has("location")).isTrue();
+            }).doesNotThrowAnyException();
         });
     }
 

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
@@ -34,15 +34,12 @@ import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.SearchOptions;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.SearchInfo;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.SearchResult;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.TokenUsage;
-import com.alibaba.cloud.ai.tool.MockWeatherService;
 import com.alibaba.cloud.ai.tool.validator.DefaultToolCallValidator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.Mockito;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
@@ -54,7 +51,6 @@ import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.DefaultToolDefinition;
-import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.http.ResponseEntity;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -471,44 +467,6 @@ class DashScopeChatModelTests {
     // Object reasoningContent = response.getMetadata().get("reasoning_content");
     // assertThat(reasoningContent).isNotNull();
     // }
-
-    @Test
-    @Tag("integration")
-    @EnabledIfEnvironmentVariable(named = "AI_DASHSCOPE_API_KEY", matches = ".+")
-    void testStreamToolCallsWithRealApi() {
-        String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
-        DashScopeApi realApi = DashScopeApi.builder().apiKey(apiKey).build();
-
-        DashScopeChatOptions options = DashScopeChatOptions.builder()
-                .model(TEST_MODEL)
-                .stream(true)
-                .enableStreamToolCalls(true)
-                .internalToolExecutionEnabled(false)
-                .toolChoice(Map.of("type", "function", "function", Map.of("name", "getCurrentWeather")))
-                .toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
-                        .description("Get the weather in location")
-                        .inputType(MockWeatherService.Request.class)
-                        .build()))
-                .build();
-
-        DashScopeChatModel realModel = DashScopeChatModel.builder()
-                .dashScopeApi(realApi)
-                .defaultOptions(options)
-                .build();
-
-        Message message = new UserMessage("What's the weather in San Francisco? Use the getCurrentWeather tool.");
-        Prompt prompt = new Prompt(List.of(message), options);
-
-        List<ChatResponse> responses = realModel.stream(prompt).collectList().block();
-
-        assertThat(responses).isNotNull();
-        assertThat(responses).isNotEmpty();
-        assertThat(responses).anySatisfy(response -> {
-            AssistantMessage assistantMessage = (AssistantMessage) response.getResult().getOutput();
-            assertThat(assistantMessage.getToolCalls()).isNotEmpty();
-            assertThat(assistantMessage.getToolCalls().get(0).name()).isEqualTo("getCurrentWeather");
-        });
-    }
 
     @Test
     void testNullToolNameHandling() {

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
@@ -60,6 +60,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -156,7 +157,8 @@ class DashScopeChatModelTests {
         ChatCompletionChunk chunk2 = new ChatCompletionChunk(TEST_REQUEST_ID, output2, null, null);
         ChatCompletionChunk chunk3 = new ChatCompletionChunk(TEST_REQUEST_ID, output3, new TokenUsage(10, 5, 15, null, null, null, null, null, null, null), null);
 
-        when(dashScopeApi.chatCompletionStream(any(ChatCompletionRequest.class), any())).thenReturn(Flux.just(chunk1, chunk2, chunk3));
+        when(dashScopeApi.chatCompletionStream(any(ChatCompletionRequest.class), any(), anyBoolean()))
+                .thenReturn(Flux.just(chunk1, chunk2, chunk3));
 
         // Execute test
         Flux<ChatResponse> responseFlux = chatModel.stream(prompt);
@@ -280,7 +282,8 @@ class DashScopeChatModelTests {
         ChatCompletionChunk chunk2Response = new ChatCompletionChunk("test-id", new ChatCompletionOutput(chunk2, List.of(choice2), null), null, null);
         ChatCompletionChunk chunk3Response = new ChatCompletionChunk("test-id", new ChatCompletionOutput(chunk3, List.of(choice3), null), new TokenUsage(10, 5, 15, null, null, null, null, null, null, null), null);
 
-        when(dashScopeApi.chatCompletionStream(any(), any())).thenReturn(Flux.just(chunk1Response, chunk2Response, chunk3Response));
+        when(dashScopeApi.chatCompletionStream(any(), any(), anyBoolean()))
+                .thenReturn(Flux.just(chunk1Response, chunk2Response, chunk3Response));
 
         Message message = new UserMessage("What's the weather like?");
         Prompt prompt = new Prompt(List.of(message), options);
@@ -644,7 +647,8 @@ class DashScopeChatModelTests {
         Message message = new UserMessage("Test error handling");
         Prompt prompt = new Prompt(List.of(message));
 
-        when(dashScopeApi.chatCompletionStream(any(), any())).thenReturn(Flux.error(new com.alibaba.cloud.ai.dashscope.common.DashScopeException("InvalidParameter  (requestId: error-request-123)")));
+        when(dashScopeApi.chatCompletionStream(any(), any(), anyBoolean()))
+                .thenReturn(Flux.error(new com.alibaba.cloud.ai.dashscope.common.DashScopeException("InvalidParameter  (requestId: error-request-123)")));
 
         Flux<ChatResponse> responseFlux = chatModel.stream(prompt);
 
@@ -790,7 +794,7 @@ class DashScopeChatModelTests {
         TokenUsage usage = new TokenUsage(10, 5, 15, null, null, null, null, null, null, null);
         ChatCompletionChunk chunk2 = new ChatCompletionChunk(TEST_REQUEST_ID, output2, usage, null);
 
-        when(dashScopeApi.chatCompletionStream(any(ChatCompletionRequest.class), any()))
+        when(dashScopeApi.chatCompletionStream(any(ChatCompletionRequest.class), any(), anyBoolean()))
                 .thenReturn(Flux.just(chunk1, chunk2));
 
         // Create prompt
@@ -837,7 +841,7 @@ class DashScopeChatModelTests {
         TokenUsage usage = new TokenUsage(10, 5, 15, null, null, null, null, null, null, null);
         ChatCompletionChunk chunk = new ChatCompletionChunk(TEST_REQUEST_ID, output, usage, null);
 
-        when(dashScopeApi.chatCompletionStream(any(ChatCompletionRequest.class), any()))
+        when(dashScopeApi.chatCompletionStream(any(ChatCompletionRequest.class), any(), anyBoolean()))
                 .thenReturn(Flux.just(chunk));
 
         // Create prompt

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
@@ -34,12 +34,15 @@ import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.SearchOptions;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.SearchInfo;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.SearchResult;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.TokenUsage;
+import com.alibaba.cloud.ai.tool.MockWeatherService;
 import com.alibaba.cloud.ai.tool.validator.DefaultToolCallValidator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.Mockito;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
@@ -51,6 +54,7 @@ import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.DefaultToolDefinition;
+import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.http.ResponseEntity;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -467,6 +471,44 @@ class DashScopeChatModelTests {
     // Object reasoningContent = response.getMetadata().get("reasoning_content");
     // assertThat(reasoningContent).isNotNull();
     // }
+
+    @Test
+    @Tag("integration")
+    @EnabledIfEnvironmentVariable(named = "AI_DASHSCOPE_API_KEY", matches = ".+")
+    void testStreamToolCallsWithRealApi() {
+        String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
+        DashScopeApi realApi = DashScopeApi.builder().apiKey(apiKey).build();
+
+        DashScopeChatOptions options = DashScopeChatOptions.builder()
+                .model(TEST_MODEL)
+                .stream(true)
+                .enableStreamToolCalls(true)
+                .internalToolExecutionEnabled(false)
+                .toolChoice(Map.of("type", "function", "function", Map.of("name", "getCurrentWeather")))
+                .toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+                        .description("Get the weather in location")
+                        .inputType(MockWeatherService.Request.class)
+                        .build()))
+                .build();
+
+        DashScopeChatModel realModel = DashScopeChatModel.builder()
+                .dashScopeApi(realApi)
+                .defaultOptions(options)
+                .build();
+
+        Message message = new UserMessage("What's the weather in San Francisco? Use the getCurrentWeather tool.");
+        Prompt prompt = new Prompt(List.of(message), options);
+
+        List<ChatResponse> responses = realModel.stream(prompt).collectList().block();
+
+        assertThat(responses).isNotNull();
+        assertThat(responses).isNotEmpty();
+        assertThat(responses).anySatisfy(response -> {
+            AssistantMessage assistantMessage = (AssistantMessage) response.getResult().getOutput();
+            assertThat(assistantMessage.getToolCalls()).isNotEmpty();
+            assertThat(assistantMessage.getToolCalls().get(0).name()).isEqualTo("getCurrentWeather");
+        });
+    }
 
     @Test
     void testNullToolNameHandling() {

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptionsTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptionsTests.java
@@ -67,6 +67,7 @@ class DashScopeChatOptionsTests {
                 .seed(TEST_SEED)
                 .repetitionPenalty(TEST_REPETITION_PENALTY)
                 .stream(true)
+                .enableStreamToolCalls(true)
                 .enableSearch(true)
                 .incrementalOutput(true)
                 .vlHighResolutionImages(true)
@@ -84,6 +85,7 @@ class DashScopeChatOptionsTests {
         assertThat(options.getSeed()).isEqualTo(TEST_SEED);
         assertThat(options.getRepetitionPenalty()).isEqualTo(TEST_REPETITION_PENALTY);
         assertThat(options.getStream()).isTrue();
+        assertThat(options.getEnableStreamToolCalls()).isTrue();
         assertThat(options.getEnableSearch()).isTrue();
         assertThat(options.getIncrementalOutput()).isTrue();
         assertThat(options.getVlHighResolutionImages()).isTrue();
@@ -105,6 +107,7 @@ class DashScopeChatOptionsTests {
         options.setSeed(TEST_SEED);
         options.setRepetitionPenalty(TEST_REPETITION_PENALTY);
         options.setStream(true);
+        options.setEnableStreamToolCalls(true);
         options.setEnableSearch(true);
         options.setIncrementalOutput(true);
         options.setVlHighResolutionImages(true);
@@ -121,6 +124,7 @@ class DashScopeChatOptionsTests {
         assertThat(options.getSeed()).isEqualTo(TEST_SEED);
         assertThat(options.getRepetitionPenalty()).isEqualTo(TEST_REPETITION_PENALTY);
         assertThat(options.getStream()).isTrue();
+        assertThat(options.getEnableStreamToolCalls()).isTrue();
         assertThat(options.getEnableSearch()).isTrue();
         assertThat(options.getIncrementalOutput()).isTrue();
         assertThat(options.getVlHighResolutionImages()).isTrue();

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeMultiModalChatTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeMultiModalChatTests.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.ai.dashscope.chat;
 import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.MESSAGE_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.when;
 
 import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
@@ -293,7 +294,7 @@ public class DashScopeMultiModalChatTests {
             new TokenUsage(10, 5, 15, null, null, null, null, null, null, null),
             null);
 
-    when(dashScopeApi.chatCompletionStream(any(ChatCompletionRequest.class), any()))
+    when(dashScopeApi.chatCompletionStream(any(ChatCompletionRequest.class), any(), anyBoolean()))
         .thenReturn(Flux.just(chunk1, chunk2));
 
     // Create user message with resource media


### PR DESCRIPTION
### Describe what this PR does / why we need it
在 DashScopeChatOptions 中新增了 enableStreamToolCalls 配置项（默认 false）
当设置为 true 时，工具调用的片段会在工具执行之前就开始流式返回

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Close #111

### Describe how you did it
测试代码：
````
 void testStreamToolCallsWithRealApiIntegration() {
        // Get API key from environment
        String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
        if (apiKey == null || apiKey.isEmpty()) {
            throw new IllegalStateException("AI_DASHSCOPE_API_KEY environment variable is not set");
        }

        // Create real DashScope API instance
        DashScopeApi realApi = DashScopeApi.builder().apiKey(apiKey).build();

        // Create a weather request class
        record WeatherRequest(String location) {}

        // Create a real tool callback for getting weather
        ToolCallback weatherTool = FunctionToolCallback.builder("get_weather", 
                (WeatherRequest request) -> {
                    // Simulate weather API call
                    return "The weather in " + request.location() + " is sunny with 25°C";
                })
                .description("Get the current weather for a given location")
                .inputType(WeatherRequest.class)
                .build();

        // Configure options with enableStreamToolCalls=true
        DashScopeChatOptions options = DashScopeChatOptions.builder()
                .model("qwen-plus") // Use a model that supports tool calls
                .stream(true)
                .enableStreamToolCalls(true)
                .toolCallbacks(List.of(weatherTool))
                .build();

        // Create chat model with real API
        DashScopeChatModel realChatModel = DashScopeChatModel.builder()
                .dashScopeApi(realApi)
                .defaultOptions(options)
                .build();

        // Create a prompt that should trigger tool execution
        UserMessage userMessage = new UserMessage("What's the weather like in Beijing today?");
        Prompt prompt = new Prompt(List.of(userMessage), options);

        // Track states during streaming
        AtomicBoolean receivedToolCallChunks = new AtomicBoolean(false);
        AtomicBoolean receivedToolExecutionResult = new AtomicBoolean(false);
        AtomicBoolean hasToolCalls = new AtomicBoolean(false);

        // Execute streaming request
        List<ChatResponse> responses = realChatModel.stream(prompt)
                .doOnNext(response -> {
                    System.out.println("=== Received Chunk ===");
                    System.out.println("Text: " + response.getResult().getOutput().getText());
                    
                    // Check if this chunk has tool calls
                    if (!response.getResult().getOutput().getToolCalls().isEmpty()) {
                        hasToolCalls.set(true);
                        receivedToolCallChunks.set(true);
                        System.out.println("Tool Calls: " + response.getResult().getOutput().getToolCalls());
                    }

                    // Check finish reason
                    String finishReason = response.getResult().getMetadata().getFinishReason();
                    System.out.println("Finish Reason: " + finishReason);

                    // Check if tool execution result is present
                    if (response.getResult().getOutput().getText().contains("sunny") 
                            || response.getResult().getOutput().getText().contains("25°C")) {
                        receivedToolExecutionResult.set(true);
                        System.out.println("Tool execution result detected in response");
                    }
                })
                .collectList()
                .block();

        // Verify results
        assertThat(responses).isNotNull();
        assertThat(responses).isNotEmpty();

        // Verify that we received tool call chunks during streaming
        assertThat(receivedToolCallChunks.get())
                .as("Should have received tool call chunks during streaming")
                .isTrue();

        // Verify that tool execution happened and result was received
        assertThat(receivedToolExecutionResult.get())
                .as("Should have received tool execution result in final response")
                .isTrue();

        // Print summary
        System.out.println("\n=== Test Summary ===");
        System.out.println("Total chunks received: " + responses.size());
        System.out.println("Tool calls detected: " + hasToolCalls.get());
        System.out.println("Tool execution result received: " + receivedToolExecutionResult.get());

        // Verify the final response contains expected content
        String finalText = responses.stream()
                .map(r -> r.getResult().getOutput().getText())
                .reduce("", (a, b) -> a + b);
        
        System.out.println("Final combined text: " + finalText);
        
        // The final text should contain either the tool call information or the weather result
        assertThat(finalText)
                .as("Final response should contain weather-related information")
                .isNotEmpty();
    }
````
得到结果
```
Running com.alibaba.cloud.ai.dashscope.chat.DashScopeChatModelTests
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
21:57:13.649 [main] WARN com.alibaba.cloud.ai.tool.validator.DefaultToolCallValidator -- Filtering out toolCall with null function name: ToolCall[id=tool-call-id, type=function, function=ChatCompletionFunction[name=null, arguments={"location": "Beijing"}], index=null]
=== Received Chunk ===
Text:
Tool Calls: [ToolCall[id=call_1f37553f6d0540208c9493, type=function, name=get_weather, arguments={"location": "]]
Finish Reason:
21:57:15.047 [HttpClient-2-Worker-0] WARN com.alibaba.cloud.ai.tool.validator.DefaultToolCallValidator -- Filtering out toolCall with null function name: ToolCall[id=, type=function, function=ChatCompletionFunction[name=null, arguments=Beijing"}], index=0]
=== Received Chunk ===
Text:
Finish Reason: TOOL_CALLS
=== Received Chunk ===
Text: The
Finish Reason:
=== Received Chunk ===
Text:  weather in
Finish Reason:
=== Received Chunk ===
Text:  Beijing today is
Finish Reason:
=== Received Chunk ===
Text:  sunny with a
Finish Reason:
Tool execution result detected in response
=== Received Chunk ===
Text:  temperature of 25°C
Finish Reason:
Tool execution result detected in response
=== Received Chunk ===
Text: .
Finish Reason:
=== Received Chunk ===
Text:
Finish Reason: STOP

=== Test Summary ===
Total chunks received: 9
Tool calls detected: true
Tool execution result received: true
Final combined text: The weather in Beijing today is sunny with a temperature of 25°C.
```

### Describe how to verify it


### Special notes for reviews
