### PR TITLE
feat(dashscope): Add cache control and performance monitor

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/common/DashScopeApiConstants.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/common/DashScopeApiConstants.java
@@ -118,6 +118,12 @@ public final class DashScopeApiConstants {
 
 	public static final String MESSAGE_FORMAT = "messageFormat";
 
+	/**
+	 * Metadata key for cache control. When set to a Map containing {"type": "ephemeral"},
+	 * the system will create or hit an explicit cache for the message content.
+	 */
+	public static final String CACHE_CONTROL = "cache_control";
+
 	public static final int MAX_TRY_COUNT = 10;
 
 	public static String RETRIEVED_DOCUMENTS = "question_answer_context";

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/metadata/DashScopeAiUsage.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/metadata/DashScopeAiUsage.java
@@ -62,10 +62,14 @@ public class DashScopeAiUsage implements Usage {
 		}
 	}
 
+	/**
+	 * Returns the DashScope native {@link TokenUsage} object containing all original fields.
+	 */
 	@Override
 	public Object getNativeUsage() {
-		return null;
+		return this.usage;
 	}
+
 
 	@Override
 	public String toString() {

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
@@ -938,21 +938,37 @@ public class DashScopeApiSpec {
          * @param video The image list of video. by adding multiple image_url content
          * parts. Image input is only supported when using the glm-4v model.
          * @param audio The audio content of the message.
+         * @param cacheControl The cache control settings for explicit caching.
+         * When set to {"type": "ephemeral"}, the system will attempt to hit or create a cache.
          */
         @JsonInclude(JsonInclude.Include.NON_NULL)
         public record MediaContent(@JsonProperty("type") String type, @JsonProperty("text") String text,
                                    @JsonProperty("image") String image, @JsonProperty("video") List<String> video,
-                                   @JsonProperty("audio") String audio) {
+                                   @JsonProperty("audio") String audio,
+                                   @JsonProperty("cache_control") Map<String, String> cacheControl) {
             /**
              * Shortcut constructor for a text content.
              * @param text The text content of the message.
              */
             public MediaContent(String text) {
-                this("text", text, null, null);
+                this("text", text, null, null, null, null);
+            }
+
+            /**
+             * Constructor for a text content with cache control.
+             * @param text The text content of the message.
+             * @param cacheControl The cache control settings.
+             */
+            public MediaContent(String text, Map<String, String> cacheControl) {
+                this("text", text, null, null, null, cacheControl);
             }
 
             public MediaContent(String type, String text, String image, List<String> video) {
-                this(type, text, image, video, null);
+                this(type, text, image, video, null, null);
+            }
+
+            public MediaContent(String type, String text, String image, List<String> video, String audio) {
+                this(type, text, image, video, audio, null);
             }
         }
 


### PR DESCRIPTION
此次更新为 `DashScopeChatModel` 添加了缓存控制功能以及内部调用时间监控。具体包括：
- 在 `MediaContent` 中添加了 `cache_control` 参数支持。
- 引入了从消息元数据中提取缓存控制设置的功能。
- 记录了内部调用的时间消耗。
- 更新了 `DashScopeAiUsage` 类以返回完整的原生 `TokenUsage` 对象，增加了相关的单元测试。



Closes: #135 添加对缓存的观测、显式缓存的使用能力