### PR TITLE
fix(dashscope-audio-speech): prevent hardcoded defaults from overwriting yml configuration in mergeOptions

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/DashScopeAudioSpeechModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/DashScopeAudioSpeechModel.java
@@ -147,15 +147,15 @@ public class DashScopeAudioSpeechModel implements TextToSpeechModel {
 	}
 
 	private DashScopeAudioSpeechOptions mergeOptions(TextToSpeechPrompt prompt) {
-		DashScopeAudioSpeechOptions options = DashScopeAudioSpeechOptions.builder().build();
-		if (prompt.getOptions() != null) {
-			DashScopeAudioSpeechOptions runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(),
-				TextToSpeechOptions.class, DashScopeAudioSpeechOptions.class);
+		DashScopeAudioSpeechOptions runtimeOptions = null;
 
-			options = ModelOptionsUtils.merge(runtimeOptions, options, DashScopeAudioSpeechOptions.class);
+		if (prompt != null && prompt.getOptions() != null) {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), TextToSpeechOptions.class,
+				DashScopeAudioSpeechOptions.class);
 		}
 
-		return ModelOptionsUtils.merge(options, this.defaultOptions, DashScopeAudioSpeechOptions.class);
+		return (runtimeOptions == null) ? this.defaultOptions
+			: ModelOptionsUtils.merge(runtimeOptions, this.defaultOptions, DashScopeAudioSpeechOptions.class);
 	}
 
     /**


### PR DESCRIPTION
Fix #150

`DashScopeAudioSpeechModel.mergeOptions()` creates an intermediate options object with hardcoded defaults (speed=1.0, volume=50, etc.), which overwrites yml configuration values.

**Fix:** Return `defaultOptions` directly when no runtime options are provided, avoiding unnecessary merge with hardcoded defaults.
