### PR TITLE
feat: Make RetryTemplate and ResponseErrorHandler optional (#141)

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAgentAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAgentAutoConfiguration.java
@@ -20,6 +20,7 @@ import com.alibaba.cloud.ai.dashscope.agent.DashScopeAgent;
 import com.alibaba.cloud.ai.dashscope.api.DashScopeAgentApi;
 
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -46,7 +47,7 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
 @ConditionalOnClass(DashScopeAgentApi.class)
 @ConditionalOnProperty(prefix = DashScopeAgentProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
 @AutoConfiguration(after = {RestClientAutoConfiguration.class, SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class})
-@ImportAutoConfiguration(classes = {SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class, ToolCallingAutoConfiguration.class, WebClientAutoConfiguration.class})
+@ImportAutoConfiguration(classes = {RestClientAutoConfiguration.class, ToolCallingAutoConfiguration.class, WebClientAutoConfiguration.class})
 @EnableConfigurationProperties({DashScopeConnectionProperties.class, DashScopeAgentProperties.class})
 public class DashScopeAgentAutoConfiguration {
 
@@ -57,7 +58,7 @@ public class DashScopeAgentAutoConfiguration {
             DashScopeAgentProperties agentProperties,
             ObjectProvider<RestClient.Builder> restClientBuilderProvider,
             ObjectProvider<WebClient.Builder> webClientBuilderProvider,
-            ResponseErrorHandler responseErrorHandler) {
+            ObjectProvider<ResponseErrorHandler> responseErrorHandler) {
 
         var resolved = resolveConnectionProperties(commonProperties, agentProperties, "agent");
 
@@ -68,7 +69,7 @@ public class DashScopeAgentAutoConfiguration {
                 .agentPath(agentProperties.getAgentPath())
                 .restClientBuilder(restClientBuilderProvider.getIfAvailable(RestClient::builder))
                 .webClientBuilder(webClientBuilderProvider.getIfAvailable(WebClient::builder))
-                .responseErrorHandler(responseErrorHandler)
+                .responseErrorHandler(responseErrorHandler.getIfAvailable(() -> RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER))
                 .build();
 
         var dashScopeAgent = DashScopeAgent.builder()

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioSpeechAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioSpeechAutoConfiguration.java
@@ -20,7 +20,9 @@ import com.alibaba.cloud.ai.dashscope.api.DashScopeAudioSpeechApi;
 import com.alibaba.cloud.ai.dashscope.audio.DashScopeAudioSpeechModel;
 import com.alibaba.cloud.ai.model.SpringAIAlibabaModels;
 import org.springframework.ai.model.SpringAIModelProperties;
+import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -46,21 +48,20 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
 @ConditionalOnProperty(name = SpringAIModelProperties.AUDIO_SPEECH_MODEL, havingValue = SpringAIAlibabaModels.DASHSCOPE,
 		matchIfMissing = true)
 @EnableConfigurationProperties({ DashScopeConnectionProperties.class, DashScopeAudioSpeechSynthesisProperties.class })
-@ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
-		WebClientAutoConfiguration.class })
+@ImportAutoConfiguration(classes = { RestClientAutoConfiguration.class, WebClientAutoConfiguration.class })
 public class DashScopeAudioSpeechAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
 	public DashScopeAudioSpeechModel dashScopeSpeechSynthesisModel(DashScopeConnectionProperties commonProperties,
-			DashScopeAudioSpeechSynthesisProperties audioSpeechProperties, RetryTemplate retryTemplate) {
+			DashScopeAudioSpeechSynthesisProperties audioSpeechProperties, ObjectProvider<RetryTemplate> retryTemplate) {
 
 		var dashScopeSpeechSynthesisApi = audioSpeechApi(commonProperties, audioSpeechProperties);
 
 		return DashScopeAudioSpeechModel.builder()
                 .audioSpeechApi(dashScopeSpeechSynthesisApi)
                 .defaultOptions(audioSpeechProperties.getOptions())
-                .retryTemplate(retryTemplate)
+                .retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
                 .build();
 	}
 

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioTranscriptionAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioTranscriptionAutoConfiguration.java
@@ -21,6 +21,7 @@ import com.alibaba.cloud.ai.dashscope.audio.DashScopeAudioTranscriptionModel;
 import com.alibaba.cloud.ai.model.SpringAIAlibabaModels;
 import org.springframework.ai.model.SimpleApiKey;
 import org.springframework.ai.model.SpringAIModelProperties;
+import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -54,7 +55,6 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
 		DashScopeConnectionProperties.class,
 		DashScopeAudioTranscriptionProperties.class })
 @ImportAutoConfiguration(classes = {
-		SpringAiRetryAutoConfiguration.class,
 		RestClientAutoConfiguration.class })
 // @formatter:on
 public class DashScopeAudioTranscriptionAutoConfiguration {
@@ -65,9 +65,8 @@ public class DashScopeAudioTranscriptionAutoConfiguration {
 			DashScopeConnectionProperties commonProperties,
 			DashScopeAudioTranscriptionProperties audioTranscriptionProperties,
 			ObjectProvider<RestClient.Builder> restClientBuilderProvider,
-			RetryTemplate retryTemplate,
-			ResponseErrorHandler responseErrorHandle
-	) {
+			ObjectProvider<RetryTemplate> retryTemplate,
+			ObjectProvider<ResponseErrorHandler> responseErrorHandler) {
 
 		ResolvedConnectionProperties resolved = resolveConnectionProperties(commonProperties,
 				audioTranscriptionProperties, "audio.transcription");
@@ -79,13 +78,13 @@ public class DashScopeAudioTranscriptionAutoConfiguration {
 			.workSpaceId(resolved.workspaceId())
 			.restClientBuilder(restClientBuilderProvider.getIfAvailable(RestClient::builder))
 			.headers(resolved.headers())
-			.responseErrorHandler(responseErrorHandle)
+			.responseErrorHandler(responseErrorHandler.getIfAvailable(() -> RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER))
 			.build();
 
 		return DashScopeAudioTranscriptionModel.builder()
                 .audioTranscriptionApi(dashScopeAudioTranscriptionApi)
                 .defaultOptions(audioTranscriptionProperties.getOptions())
-                .retryTemplate(retryTemplate)
+                .retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
                 .build();
 	}
 

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicat
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -50,7 +51,7 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
  * @author yuluo
  * @since 2024/8/16 11:45
  *
- * Spring AI Alibaba DashScope Chat Configuration.
+ *        Spring AI Alibaba DashScope Chat Configuration.
  */
 
 // @formatter:off
@@ -64,7 +65,6 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
 		SpringAiRetryAutoConfiguration.class,
         ToolCallingAutoConfiguration.class})
 @ImportAutoConfiguration(classes = {
-		SpringAiRetryAutoConfiguration.class,
 		RestClientAutoConfiguration.class,
 		ToolCallingAutoConfiguration.class,
 		WebClientAutoConfiguration.class
@@ -78,10 +78,10 @@ public class DashScopeChatAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		public DashScopeChatModel dashScopeChatModel(
-				RetryTemplate retryTemplate,
+				ObjectProvider<RetryTemplate> retryTemplate,
 				ToolCallingManager toolCallingManager,
 				DashScopeChatProperties chatProperties,
-				ResponseErrorHandler responseErrorHandler,
+				ObjectProvider<ResponseErrorHandler> responseErrorHandler,
 				DashScopeConnectionProperties commonProperties,
 				ObjectProvider<ObservationRegistry> observationRegistry,
 				ObjectProvider<WebClient.Builder> webClientBuilderProvider,
@@ -96,13 +96,13 @@ public class DashScopeChatAutoConfiguration {
 					chatProperties,
 					restClientBuilderProvider.getIfAvailable(RestClient::builder),
 					webClientBuilderProvider.getIfAvailable(WebClient::builder),
-					responseErrorHandler,
+					responseErrorHandler.getIfAvailable(() -> RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER),
 					"chat"
 			);
 
 			var dashscopeModel = DashScopeChatModel.builder()
 					.dashScopeApi(dashscopeApi)
-					.retryTemplate(retryTemplate)
+					.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
 					.toolCallingManager(toolCallingManager)
 					.defaultOptions(chatProperties.getOptions())
 					.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeEmbeddingAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeEmbeddingAutoConfiguration.java
@@ -23,6 +23,8 @@ import io.micrometer.observation.ObservationRegistry;
 
 import org.springframework.ai.embedding.observation.EmbeddingModelObservationConvention;
 import org.springframework.ai.model.SpringAIModelProperties;
+import org.springframework.ai.retry.RetryUtils;
+
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -53,8 +55,7 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
 @ConditionalOnProperty(name = SpringAIModelProperties.EMBEDDING_MODEL, havingValue = SpringAIAlibabaModels.DASHSCOPE,
 		matchIfMissing = true)
 @EnableConfigurationProperties({ DashScopeConnectionProperties.class, DashScopeEmbeddingProperties.class })
-@ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
-		WebClientAutoConfiguration.class })
+@ImportAutoConfiguration(classes = { RestClientAutoConfiguration.class, WebClientAutoConfiguration.class })
 public class DashScopeEmbeddingAutoConfiguration {
 
 	@Bean
@@ -62,19 +63,21 @@ public class DashScopeEmbeddingAutoConfiguration {
 	public DashScopeEmbeddingModel dashscopeEmbeddingModel(DashScopeConnectionProperties commonProperties,
 			DashScopeEmbeddingProperties embeddingProperties,
 			ObjectProvider<WebClient.Builder> webClientBuilderProvider,
-			ObjectProvider<RestClient.Builder> restClientBuilderProvider, RetryTemplate retryTemplate,
-			ResponseErrorHandler responseErrorHandler, ObjectProvider<ObservationRegistry> observationRegistry,
+			ObjectProvider<RestClient.Builder> restClientBuilderProvider, ObjectProvider<RetryTemplate> retryTemplate,
+			ObjectProvider<ResponseErrorHandler> responseErrorHandler,
+			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<EmbeddingModelObservationConvention> observationConvention) {
 
 		var dashScopeApi = dashscopeEmbeddingApi(commonProperties, embeddingProperties,
 				restClientBuilderProvider.getIfAvailable(RestClient::builder),
-				webClientBuilderProvider.getIfAvailable(WebClient::builder), responseErrorHandler);
+				webClientBuilderProvider.getIfAvailable(WebClient::builder),
+				responseErrorHandler.getIfAvailable(() -> RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER));
 
 		var embeddingModel = DashScopeEmbeddingModel.builder()
                 .dashScopeApi(dashScopeApi)
                 .metadataMode(embeddingProperties.getMetadataMode())
                 .defaultOptions(embeddingProperties.getOptions())
-                .retryTemplate(retryTemplate)
+                .retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
                 .observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
                 .build();
 

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeImageAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeImageAutoConfiguration.java
@@ -22,6 +22,7 @@ import com.alibaba.cloud.ai.model.SpringAIAlibabaModels;
 import io.micrometer.observation.ObservationRegistry;
 import org.springframework.ai.image.observation.ImageModelObservationConvention;
 import org.springframework.ai.model.SpringAIModelProperties;
+import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -51,15 +52,14 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
 @ConditionalOnProperty(name = SpringAIModelProperties.IMAGE_MODEL, havingValue = SpringAIAlibabaModels.DASHSCOPE,
 		matchIfMissing = true)
 @EnableConfigurationProperties({ DashScopeConnectionProperties.class, DashScopeImageProperties.class })
-@ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
-		WebClientAutoConfiguration.class })
+@ImportAutoConfiguration(classes = { RestClientAutoConfiguration.class, WebClientAutoConfiguration.class })
 public class DashScopeImageAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
 	public DashScopeImageModel dashScopeImageModel(DashScopeConnectionProperties commonProperties,
 			DashScopeImageProperties imageProperties, ObjectProvider<RestClient.Builder> restClientBuilderProvider,
-			RetryTemplate retryTemplate, ResponseErrorHandler responseErrorHandler,
+			ObjectProvider<RetryTemplate> retryTemplate, ObjectProvider<ResponseErrorHandler> responseErrorHandler,
 			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<ImageModelObservationConvention> observationConvention) {
 
@@ -72,13 +72,13 @@ public class DashScopeImageAutoConfiguration {
             .queryTaskPath(imageProperties.getQueryTaskPath())
 			.workSpaceId(resolved.workspaceId())
 			.restClientBuilder(restClientBuilderProvider.getIfAvailable(RestClient::builder))
-			.responseErrorHandler(responseErrorHandler)
+			.responseErrorHandler(responseErrorHandler.getIfAvailable(() -> RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER))
 			.build();
 
 		var dashScopeImageModel = DashScopeImageModel.builder()
                 .dashScopeApi(dashScopeImageApi)
                 .defaultOptions(imageProperties.getOptions())
-                .retryTemplate(retryTemplate)
+                .retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
                 .observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
                 .build();
 

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeRerankAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeRerankAutoConfiguration.java
@@ -21,6 +21,8 @@ import com.alibaba.cloud.ai.dashscope.rerank.DashScopeRerankModel;
 import com.alibaba.cloud.ai.model.SpringAIAlibabaModelProperties;
 import com.alibaba.cloud.ai.model.SpringAIAlibabaModels;
 
+import org.springframework.ai.retry.RetryUtils;
+
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -52,16 +54,15 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
 @ConditionalOnProperty(name = SpringAIAlibabaModelProperties.RERANK_MODEL,
 		havingValue = SpringAIAlibabaModels.DASHSCOPE, matchIfMissing = true)
 @EnableConfigurationProperties({ DashScopeConnectionProperties.class, DashScopeRerankProperties.class })
-@ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
-		WebClientAutoConfiguration.class })
+@ImportAutoConfiguration(classes = { RestClientAutoConfiguration.class, WebClientAutoConfiguration.class })
 public class DashScopeRerankAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
 	public DashScopeRerankModel dashscopeRerankModel(DashScopeConnectionProperties commonProperties,
 			DashScopeRerankProperties rerankProperties, ObjectProvider<Builder> restClientBuilderProvider,
-			ObjectProvider<WebClient.Builder> webClientBuilderProvider, RetryTemplate retryTemplate,
-			ResponseErrorHandler responseErrorHandler) {
+			ObjectProvider<WebClient.Builder> webClientBuilderProvider, ObjectProvider<RetryTemplate> retryTemplate,
+			ObjectProvider<ResponseErrorHandler> responseErrorHandler) {
 
 		ResolvedConnectionProperties resolved = resolveConnectionProperties(commonProperties, rerankProperties,
 				"rerank");
@@ -74,13 +75,13 @@ public class DashScopeRerankAutoConfiguration {
 			.webClientBuilder(webClientBuilderProvider.getIfAvailable(WebClient::builder))
 			.workSpaceId(resolved.workspaceId())
 			.restClientBuilder(restClientBuilderProvider.getIfAvailable(RestClient::builder))
-			.responseErrorHandler(responseErrorHandler)
+			.responseErrorHandler(responseErrorHandler.getIfAvailable(() -> RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER))
 			.build();
 
 		return DashScopeRerankModel.builder()
                 .dashScopeApi(dashScopeApi)
                 .defaultOptions(rerankProperties.getOptions())
-                .retryTemplate(retryTemplate)
+                .retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
                 .build();
 	}
 

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeVideoAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeVideoAutoConfiguration.java
@@ -19,6 +19,7 @@ import com.alibaba.cloud.ai.dashscope.api.DashScopeVideoApi;
 import com.alibaba.cloud.ai.dashscope.video.DashScopeVideoModel;
 import com.alibaba.cloud.ai.model.SpringAIAlibabaModelProperties;
 import com.alibaba.cloud.ai.model.SpringAIAlibabaModels;
+import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -49,14 +50,14 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
 @ConditionalOnProperty(name = SpringAIAlibabaModelProperties.VIDEO_MODEL, havingValue = SpringAIAlibabaModels.DASHSCOPE,
 		matchIfMissing = true)
 @EnableConfigurationProperties({ DashScopeConnectionProperties.class, DashScopeVideoProperties.class })
-@ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class, })
+@ImportAutoConfiguration(classes = { RestClientAutoConfiguration.class })
 public class DashScopeVideoAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
 	public DashScopeVideoModel dashScopeVideoModel(DashScopeConnectionProperties commonProperties,
 			DashScopeVideoProperties videoProperties, ObjectProvider<RestClient.Builder> restClientBuilderProvider,
-			RetryTemplate retryTemplate, ResponseErrorHandler responseErrorHandler) {
+			ObjectProvider<RetryTemplate> retryTemplate, ObjectProvider<ResponseErrorHandler> responseErrorHandler) {
 
         ResolvedConnectionProperties resolved = resolveConnectionProperties(commonProperties, videoProperties, "video");
 
@@ -66,7 +67,7 @@ public class DashScopeVideoAutoConfiguration {
             .videoPath(videoProperties.getVideoPath())
             .queryTaskPath(videoProperties.getQueryTaskPath())
 			.restClientBuilder(restClientBuilderProvider.getIfAvailable(RestClient::builder))
-			.responseErrorHandler(responseErrorHandler)
+			.responseErrorHandler(responseErrorHandler.getIfAvailable(() -> RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER))
 			.build();
 
 		// todo: add observation
@@ -74,7 +75,7 @@ public class DashScopeVideoAutoConfiguration {
 		return DashScopeVideoModel.builder()
 			.videoApi(videoApi)
 			.defaultOptions(videoProperties.getOptions())
-			.retryTemplate(retryTemplate)
+			.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
 			.build();
 	}
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
This PR makes `RetryTemplate` and `ResponseErrorHandler` optional in DashScope auto-configurations to avoid hard dependencies and improve flexibility.

### Does this pull request fix one issue?
Closes #141

### Describe how you did it
- Use `ObjectProvider` for `RetryTemplate` (fallback to `getIfUnique`) and `ResponseErrorHandler` (fallback to `getIfAvailable`).
- Remove `SpringAiRetryAutoConfiguration` from `@ImportAutoConfiguration`.

### Describe how to verify it
Build and run existing tests.

### Special notes for reviews
NONE