### PR TITLE
feat: implement initialize-schema support for vector store modules

### DIFF
--- a/vector-stores/spring-ai-alibaba-starter-analyticdb-store/src/main/java/com/alibaba/cloud/ai/vectorstore/analyticdb/AnalyticDbVectorStore.java
+++ b/vector-stores/spring-ai-alibaba-starter-analyticdb-store/src/main/java/com/alibaba/cloud/ai/vectorstore/analyticdb/AnalyticDbVectorStore.java
@@ -83,7 +83,7 @@ public class AnalyticDbVectorStore extends AbstractObservationVectorStore implem
 
 	public final FilterExpressionConverter filterExpressionConverter = new AdVectorFilterExpressionConverter();
 
-	// private final boolean initializeSchema;
+	private final boolean initializeSchema;
 
 	private final String collectionName;
 
@@ -106,6 +106,7 @@ public class AnalyticDbVectorStore extends AbstractObservationVectorStore implem
 		this.objectMapper = JsonMapper.builder().addModules(JacksonUtils.instantiateAvailableModules()).build();
 		this.defaultSimilarityThreshold = builder.defaultSimilarityThreshold;
 		this.defaultTopK = builder.defaultTopK;
+		this.initializeSchema = builder.initializeSchema;
 	}
 
 	public static Builder builder(String collectionName, AnalyticDbConfig config, Client client,
@@ -361,6 +362,9 @@ public class AnalyticDbVectorStore extends AbstractObservationVectorStore implem
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
+		if (!this.initializeSchema) {
+			return;
+		}
 		initialize();
 		logger.debug("created AnalyticdbVector client success");
 	}
@@ -393,6 +397,8 @@ public class AnalyticDbVectorStore extends AbstractObservationVectorStore implem
 		private int defaultTopK = DEFAULT_TOP_K;
 
 		private Double defaultSimilarityThreshold = DEFAULT_SIMILARITY_THRESHOLD;
+
+		private boolean initializeSchema = false;
 
 		private Builder(String collectionName, AnalyticDbConfig config, Client client, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
@@ -427,6 +433,11 @@ public class AnalyticDbVectorStore extends AbstractObservationVectorStore implem
 			Assert.isTrue(defaultSimilarityThreshold >= 0.0 && defaultSimilarityThreshold <= 1.0,
 					"The similarity threshold must be in range [0.0:1.00].");
 			this.defaultSimilarityThreshold = defaultSimilarityThreshold;
+			return this;
+		}
+
+		public Builder initializeSchema(boolean initializeSchema) {
+			this.initializeSchema = initializeSchema;
 			return this;
 		}
 

--- a/vector-stores/spring-ai-alibaba-starter-analyticdb-store/src/main/java/com/alibaba/cloud/ai/vectorstore/analyticdb/AnalyticDbVectorStoreAutoConfiguration.java
+++ b/vector-stores/spring-ai-alibaba-starter-analyticdb-store/src/main/java/com/alibaba/cloud/ai/vectorstore/analyticdb/AnalyticDbVectorStoreAutoConfiguration.java
@@ -81,7 +81,7 @@ public class AnalyticDbVectorStoreAutoConfiguration {
 		var builder = AnalyticDbVectorStore.builder(properties.getCollectName(), config, client, embeddingModel)
 			.batchingStrategy(batchingStrategy)
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
-			.customObservationConvention(customObservationConvention.getIfAvailable(() -> null));
+			.customObservationConvention(customObservationConvention.getIfAvailable());
 		if (properties.getDefaultTopK() >= 0) {
 			builder.defaultTopK(properties.getDefaultTopK());
 		}
@@ -89,7 +89,7 @@ public class AnalyticDbVectorStoreAutoConfiguration {
 		if (properties.getDefaultSimilarityThreshold() >= 0.0) {
 			builder.defaultSimilarityThreshold(properties.getDefaultSimilarityThreshold());
 		}
-		return builder.build();
+		return builder.initializeSchema(properties.isInitializeSchema()).build();
 	}
 
 }

--- a/vector-stores/spring-ai-alibaba-starter-analyticdb-store/src/test/java/com/alibaba/cloud/ai/vectorstore/analyticdb/AnalyticDbVectorTest.java
+++ b/vector-stores/spring-ai-alibaba-starter-analyticdb-store/src/test/java/com/alibaba/cloud/ai/vectorstore/analyticdb/AnalyticDbVectorTest.java
@@ -52,10 +52,11 @@ import static org.hamcrest.Matchers.hasSize;
 class AnalyticDbVectorTest {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-		.withConfiguration(AutoConfigurations.of(AnalyticDbVectorStoreProperties.class))
+		.withConfiguration(AutoConfigurations.of(AnalyticDbVectorStoreAutoConfiguration.class))
 		.withUserConfiguration(Config.class)
 		.withPropertyValues("spring.ai.vectorstore.analytic.accessKeyId=" + System.getenv("ANALYTICDB_ACCESS_KEY_ID"),
-				"spring.ai.vectorstore.analytic.accessKeyId=" + System.getenv("ANALYTICDB_ACCESS_KEY_SECRET"));
+				"spring.ai.vectorstore.analytic.accessKeyId=" + System.getenv("ANALYTICDB_ACCESS_KEY_SECRET"),
+				"spring.ai.vectorstore.analytic.initialize-schema=true");
 
 	List<Document> documents = List.of(
 			new Document("1", getText("classpath:spring.ai.txt"), Map.of("docId", "1", "spring", "great")),

--- a/vector-stores/spring-ai-alibaba-starter-oceanbase-store/src/main/java/com/alibaba/cloud/ai/vectorstore/oceanbase/OceanBaseVectorStore.java
+++ b/vector-stores/spring-ai-alibaba-starter-oceanbase-store/src/main/java/com/alibaba/cloud/ai/vectorstore/oceanbase/OceanBaseVectorStore.java
@@ -96,6 +96,7 @@ public class OceanBaseVectorStore extends AbstractObservationVectorStore impleme
 	private final String indexName;
 	private final String fulltextIndexName;
 	private final boolean enableFulltext;
+	private final boolean initializeSchema;
 
 	protected OceanBaseVectorStore(Builder builder) {
 		super(builder);
@@ -113,6 +114,7 @@ public class OceanBaseVectorStore extends AbstractObservationVectorStore impleme
 		this.indexName = generateVectorIndexName(builder.tableName);
 		this.fulltextIndexName = generateFulltextIndexName(builder.tableName);
 		this.enableFulltext = HYBRID_SEARCH_TYPE_FULLTEXT.equalsIgnoreCase(hybridSearchType);
+		this.initializeSchema = builder.initializeSchema;
 	}
 
 	public static Builder builder(String tableName, DataSource dataSource, EmbeddingModel embeddingModel) {
@@ -137,6 +139,9 @@ public class OceanBaseVectorStore extends AbstractObservationVectorStore impleme
 
 	@Override
 	public void afterPropertiesSet() {
+		if (!this.initializeSchema) {
+			return;
+		}
 		initializeDatabase();
 	}
 
@@ -706,6 +711,7 @@ public class OceanBaseVectorStore extends AbstractObservationVectorStore impleme
 		private String hybridSearchType;
 		private String indexType = INDEX_TYPE_HNSW;
 		private String indexMetricType = METRIC_TYPE_L2;
+		private boolean initializeSchema = false;
 
 		private Builder(String tableName, DataSource dataSource, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
@@ -735,6 +741,11 @@ public class OceanBaseVectorStore extends AbstractObservationVectorStore impleme
 
 		public Builder hybridSearchType(String hybridSearchType) {
 			this.hybridSearchType = hybridSearchType;
+			return this;
+		}
+
+		public Builder initializeSchema(boolean initializeSchema) {
+			this.initializeSchema = initializeSchema;
 			return this;
 		}
 

--- a/vector-stores/spring-ai-alibaba-starter-oceanbase-store/src/main/java/com/alibaba/cloud/ai/vectorstore/oceanbase/OceanBaseVectorStoreAutoConfiguration.java
+++ b/vector-stores/spring-ai-alibaba-starter-oceanbase-store/src/main/java/com/alibaba/cloud/ai/vectorstore/oceanbase/OceanBaseVectorStoreAutoConfiguration.java
@@ -71,7 +71,7 @@ public class OceanBaseVectorStoreAutoConfiguration {
 		var builder = OceanBaseVectorStore.builder(properties.getTableName(), dataSource, embeddingModel)
 			.batchingStrategy(batchingStrategy)
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
-			.customObservationConvention(customObservationConvention.getIfAvailable(() -> null));
+			.customObservationConvention(customObservationConvention.getIfAvailable());
 
 		if (properties.getDefaultTopK() >= 0) {
 			builder.defaultTopK(properties.getDefaultTopK());
@@ -89,7 +89,7 @@ public class OceanBaseVectorStoreAutoConfiguration {
 			builder.hybridSearchType(properties.getHybridSearchType());
 		}
 
-		return builder.build();
+		return builder.initializeSchema(properties.isInitializeSchema()).build();
 	}
 
 }

--- a/vector-stores/spring-ai-alibaba-starter-oceanbase-store/src/main/java/com/alibaba/cloud/ai/vectorstore/oceanbase/OceanBaseVectorStoreProperties.java
+++ b/vector-stores/spring-ai-alibaba-starter-oceanbase-store/src/main/java/com/alibaba/cloud/ai/vectorstore/oceanbase/OceanBaseVectorStoreProperties.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.vectorstore.oceanbase;
 
+import org.springframework.ai.vectorstore.properties.CommonVectorStoreProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -23,7 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author xxsc0529
  */
 @ConfigurationProperties(prefix = OceanBaseVectorStoreProperties.CONFIG_PREFIX)
-public class OceanBaseVectorStoreProperties {
+public class OceanBaseVectorStoreProperties extends CommonVectorStoreProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.vectorstore.oceanbase";
 

--- a/vector-stores/spring-ai-alibaba-starter-oceanbase-store/src/test/java/com/alibaba/cloud/ai/vectorstore/oceanbase/OceanBaseVectorTest.java
+++ b/vector-stores/spring-ai-alibaba-starter-oceanbase-store/src/test/java/com/alibaba/cloud/ai/vectorstore/oceanbase/OceanBaseVectorTest.java
@@ -129,7 +129,8 @@ class OceanBaseVectorTest {
 			.withPropertyValues("spring.ai.vectorstore.oceanbase.url=" + getJdbcUrl(),
 					"spring.ai.vectorstore.oceanbase.username=" + System.getenv("OCEANBASE_USERNAME"),
 					"spring.ai.vectorstore.oceanbase.password=" + System.getenv("OCEANBASE_PASSWORD"),
-					"spring.ai.vectorstore.oceanbase.tableName=" + System.getenv("OCEANBASE_TABLENAME"));
+					"spring.ai.vectorstore.oceanbase.tableName=" + System.getenv("OCEANBASE_TABLENAME"),
+					"spring.ai.vectorstore.oceanbase.initialize-schema=true");
 	}
 
 	@Test

--- a/vector-stores/spring-ai-alibaba-starter-opensearch-store/src/main/java/com/alibaba/cloud/ai/vectorstore/opensearch/OpenSearchVectorStore.java
+++ b/vector-stores/spring-ai-alibaba-starter-opensearch-store/src/main/java/com/alibaba/cloud/ai/vectorstore/opensearch/OpenSearchVectorStore.java
@@ -78,6 +78,11 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 	private final OpenSearchVectorStoreOptions options;
 
 	/**
+	 * Whether to initialize the schema for the vector store.
+	 */
+	private final boolean initializeSchema;
+
+	/**
 	 * The embedding model used for vector operations.
 	 */
 	private final EmbeddingModel embeddingModel;
@@ -134,6 +139,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 		Assert.notNull(builder.options.getTableName(), "The tableName cannot be null");
 
 		this.options = builder.options;
+		this.initializeSchema = builder.initializeSchema;
 		this.openSearchApi = builder.openSearchApi;
 		this.embeddingModel = builder.getEmbeddingModel();
 		this.batchingStrategy = builder.batchingStrategy;
@@ -267,7 +273,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		if (this.options.isInitializeSchema() && !exists(this.options.getIndex())) {
+		if (this.initializeSchema && !exists(this.options.getIndex())) {
 			openSearchApi.createCollectionAndIndex(this.options.getMappingJson());
 		}
 	}
@@ -294,6 +300,8 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 
 		private OpenSearchVectorStoreOptions options = new OpenSearchVectorStoreOptions();
 
+		private boolean initializeSchema = false;
+
 		private BatchingStrategy batchingStrategy = new TokenCountBatchingStrategy();
 
 		/**
@@ -316,6 +324,11 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 		public Builder options(OpenSearchVectorStoreOptions options) {
 			Assert.notNull(options, "options must not be null");
 			this.options = options;
+			return this;
+		}
+
+		public Builder initializeSchema(boolean initializeSchema) {
+			this.initializeSchema = initializeSchema;
 			return this;
 		}
 

--- a/vector-stores/spring-ai-alibaba-starter-opensearch-store/src/main/java/com/alibaba/cloud/ai/vectorstore/opensearch/OpenSearchVectorStoreAutoConfiguration.java
+++ b/vector-stores/spring-ai-alibaba-starter-opensearch-store/src/main/java/com/alibaba/cloud/ai/vectorstore/opensearch/OpenSearchVectorStoreAutoConfiguration.java
@@ -62,14 +62,16 @@ public class OpenSearchVectorStoreAutoConfiguration {
 	@ConditionalOnMissingBean
 	public OpenSearchVectorStore openSearchVectorStore(OpenSearchApi openSearchApi, EmbeddingModel embeddingModel,
 			BatchingStrategy batchingStrategy, OpenSearchVectorStoreOptions options,
+			OpenSearchVectorStoreProperties properties,
 			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention) {
 
 		return OpenSearchVectorStore.builder(openSearchApi, embeddingModel)
 			.batchingStrategy(batchingStrategy)
 			.options(options)
+			.initializeSchema(properties.isInitializeSchema())
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
-			.customObservationConvention(customObservationConvention.getIfAvailable(() -> null))
+			.customObservationConvention(customObservationConvention.getIfAvailable())
 			.build();
 	}
 

--- a/vector-stores/spring-ai-alibaba-starter-opensearch-store/src/main/java/com/alibaba/cloud/ai/vectorstore/opensearch/OpenSearchVectorStoreOptions.java
+++ b/vector-stores/spring-ai-alibaba-starter-opensearch-store/src/main/java/com/alibaba/cloud/ai/vectorstore/opensearch/OpenSearchVectorStoreOptions.java
@@ -66,11 +66,6 @@ public class OpenSearchVectorStoreOptions {
 			""";
 
 	/**
-	 * Whether to initialize the schema for the vector store.
-	 */
-	private boolean initializeSchema = false;
-
-	/**
 	 * The name of the index to store the vectors.
 	 */
 	private String tableName = DEFAULT_TABLE_NAME;
@@ -105,15 +100,6 @@ public class OpenSearchVectorStoreOptions {
 	 * The number of dimensions in the vector.
 	 */
 	private int dimensions = 1536;
-
-	public boolean isInitializeSchema() {
-		return initializeSchema;
-	}
-
-	public OpenSearchVectorStoreOptions setInitializeSchema(boolean initializeSchema) {
-		this.initializeSchema = initializeSchema;
-		return this;
-	}
 
 	public String getIndex() {
 		return index;

--- a/vector-stores/spring-ai-alibaba-starter-tair-store/pom.xml
+++ b/vector-stores/spring-ai-alibaba-starter-tair-store/pom.xml
@@ -57,6 +57,16 @@
     <dependencies>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>com.aliyun.tair</groupId>
             <artifactId>alibabacloud-tairjedis-sdk</artifactId>
             <version>5.2.0</version>

--- a/vector-stores/spring-ai-alibaba-starter-tair-store/src/main/java/com/alibaba/cloud/ai/vectorstore/tair/TairVectorStoreAutoConfiguration.java
+++ b/vector-stores/spring-ai-alibaba-starter-tair-store/src/main/java/com/alibaba/cloud/ai/vectorstore/tair/TairVectorStoreAutoConfiguration.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.vectorstore.tair;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.springframework.ai.embedding.BatchingStrategy;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.TokenCountBatchingStrategy;
+import org.springframework.ai.vectorstore.observation.VectorStoreObservationConvention;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+/**
+ * Autoconfiguration for the Tair Vector Store.
+ *
+ * @author buvidk
+ * @since 2026-2-14
+ */
+@AutoConfiguration
+@ConditionalOnClass({TairVectorStore.class, EmbeddingModel.class})
+@EnableConfigurationProperties(TairVectorStoreProperties.class)
+@ConditionalOnProperty(prefix = "spring.ai.vectorstore.tair", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class TairVectorStoreAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public TairVectorApi tairVectorApi(TairVectorStoreProperties properties) {
+        JedisPoolConfig config = new JedisPoolConfig();
+        JedisPool jedisPool = new JedisPool(config, properties.getHost(), properties.getPort(), properties.getTimeout(), properties.getPassword());
+        return new TairVectorApi(jedisPool);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(BatchingStrategy.class)
+    public BatchingStrategy tairBatchingStrategy() {
+        return new TokenCountBatchingStrategy();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public TairVectorStore tairVectorStore(
+            TairVectorApi tairVectorApi,
+            EmbeddingModel embeddingModel,
+            TairVectorStoreProperties properties,
+            BatchingStrategy batchingStrategy,
+            ObjectProvider<ObservationRegistry> observationRegistry,
+            ObjectProvider<VectorStoreObservationConvention> customObservationConvention) {
+        return TairVectorStore.builder(tairVectorApi, embeddingModel)
+                .options(properties.getOptions())
+                .batchingStrategy(batchingStrategy)
+                .initializeSchema(properties.isInitializeSchema())
+                .observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
+                .customObservationConvention(customObservationConvention.getIfAvailable())
+                .build();
+    }
+}

--- a/vector-stores/spring-ai-alibaba-starter-tair-store/src/main/java/com/alibaba/cloud/ai/vectorstore/tair/TairVectorStoreProperties.java
+++ b/vector-stores/spring-ai-alibaba-starter-tair-store/src/main/java/com/alibaba/cloud/ai/vectorstore/tair/TairVectorStoreProperties.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.vectorstore.tair;
+
+import org.springframework.ai.vectorstore.properties.CommonVectorStoreProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * Configuration properties for the Tair Vector Store.
+ *
+ * @author buvidk
+ * @since 2026-2-14
+ */
+@ConfigurationProperties(TairVectorStoreProperties.CONFIG_PREFIX)
+public class TairVectorStoreProperties extends CommonVectorStoreProperties {
+
+    public static final String CONFIG_PREFIX = "spring.ai.vectorstore.tair";
+
+    private String host = "localhost";
+
+    private int port = 6379;
+
+    private String password;
+
+    private int timeout = 2000;
+
+    @NestedConfigurationProperty
+    private final TairVectorStoreOptions options = new TairVectorStoreOptions();
+
+    public TairVectorStoreOptions getOptions() {
+        return options;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public int getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
+    }
+
+}

--- a/vector-stores/spring-ai-alibaba-starter-tair-store/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/vector-stores/spring-ai-alibaba-starter-tair-store/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.alibaba.cloud.ai.vectorstore.tair.TairVectorStoreAutoConfiguration


### PR DESCRIPTION
### Describe what this PR does / why we need it

Add `initialize-schema` property support for all vector store modules, following the [Spring AI convention](https://docs.spring.io/spring-ai/reference/api/vectordbs/elasticsearch.html#elasticsearchvector-properties).

When `spring.ai.vectorstore.<module>.initialize-schema=true`, the vector store automatically creates indexes/tables on startup. Defaults to `false`.


### Does this pull request fix one issue?

Closes #168

### Describe how you did it

| Module | What was done |
|--------|--------------|
| **Tair** | New AutoConfiguration, Properties, `afterPropertiesSet()` with idempotent index creation |
| **AnalyticDB** | Wired `initializeSchema` through Builder and AutoConfiguration, guarded `afterPropertiesSet()` |
| **OceanBase** | Extended `CommonVectorStoreProperties`, wired through Builder and AutoConfiguration |
| **OpenSearch** | Moved `initializeSchema` from Options to VectorStore, wired through Properties |
| **Tablestore** | Already supported via `initializeTable` (no AutoConfiguration, no changes needed) |

### Describe how to verify it


### Special notes for reviews
