### PR TITLE
修复服务方法描述等更新网关 gateway tool list 不更新的问题

### DIFF
--- a/mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/register/NacosMcpRegister.java
+++ b/mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/register/NacosMcpRegister.java
@@ -169,6 +169,12 @@ public class NacosMcpRegister implements ApplicationListener<WebServerInitialize
 				List<McpTool> toolsToNacosList = JacksonUtils.toObj(toolsStr, new TypeReference<>() {
 				});
 				mcpToolSpec.setTools(toolsToNacosList);
+                for (McpTool tool : toolsToNacosList) {
+                    McpToolMeta toolMeta = new McpToolMeta();
+                    toolMeta.setEnabled(true);  // 默认启用所有工具
+                    this.toolsMeta.put(tool.getName(), toolMeta);
+                }
+                mcpToolSpec.setToolsMeta(this.toolsMeta);
 			}
 			ServerVersionDetail serverVersionDetail = new ServerVersionDetail();
 			serverVersionDetail.setVersion(this.serverInfo.version());


### PR DESCRIPTION
### Describe what this PR does / why we need it
修复服务方法描述更新后，网关工具列表不自动刷新的问题。
之前修改了服务方法描述，但网关的 tool list 仍然显示旧数据，导致用户看到信息不一致。
本次修改确保更新服务方法描述后，gateway tool list 会正确刷新。

### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
在服务方法更新逻辑中增加了 gateway tool list 的刷新调用。
保证每次修改服务方法描述后，相关缓存/列表会同步更新。

### Describe how to verify it
1. 修改某个服务方法的描述
2. 查看 gateway tool list 是否立即更新显示最新描述,mcp gateway 无需重启
3. 确认旧描述不再显示，且列表功能正常

### Special notes for reviews
无特殊注意事项，修改仅影响服务方法描述更新逻辑和 gateway tool list 刷新