### PR TITLE
fix: remove default value from multiModel to prevent override during options merge

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -519,7 +519,7 @@ public class DashScopeApi {
 		Assert.notNull(additionalHttpHeader, "The additional HTTP headers can not be null.");
 
 		var chatCompletionUri = this.completionsPath;
-		if (chatRequest.multiModel()) {
+		if (Boolean.TRUE.equals(chatRequest.multiModel())) {
 			chatCompletionUri = MULTIMODAL_GENERATION_RESTFUL_URL;
 		}
 
@@ -575,7 +575,7 @@ public class DashScopeApi {
 				incrementalOutput);
 
 		var chatCompletionUri = this.completionsPath;
-		if (chatRequest.multiModel()) {
+		if (Boolean.TRUE.equals(chatRequest.multiModel())) {
 			chatCompletionUri = MULTIMODAL_GENERATION_RESTFUL_URL;
 		}
 

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -578,7 +578,7 @@ public class DashScopeChatModel implements ChatModel {
 			requestOptions.setTools(getFunctionTools(toolDefinitions));
 		}
 
-		boolean multiModel = requestOptions.getMultiModel();
+		Boolean multiModel = requestOptions.getMultiModel();
 
 		return new ChatCompletionRequest(requestOptions.getModel(),
 				new ChatCompletionRequestInput(chatCompletionMessages),

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
@@ -222,7 +222,7 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
     /**
      * Indicates whether the request involves multiple models
      */
-    private @JsonProperty("multi_model") Boolean multiModel = false;
+    private @JsonProperty("multi_model") Boolean multiModel;
 
     /**
      * Whether to enable the vision language model to output image height and width.


### PR DESCRIPTION
## Summary

Fixes issue where `multiModel=true` configuration was being overridden by the default `false` value during options merging in the Agent framework.

## Problem

When configuring a multimodal model (e.g., qwen3.5-plus, kimi-k2.5) with `DashScopeChatOptions.builder().multiModel(true)`, the setting was being overridden during the options merging process, causing requests to route to the wrong endpoint (`text-generation` instead of `multimodal-generation`).

Root cause: The `multiModel` field had a default value of `false`, which was not `null`. During `ModelOptionsUtils.merge()`, non-null values from runtime options override values from default options, causing user settings to be lost.

## Changes

- **DashScopeChatOptions.java**: Remove default value `= false` from `multiModel` field, allowing it to be `null` when not explicitly set
- **DashScopeApi.java**: Add null-safe checks using `Boolean.TRUE.equals(chatRequest.multiModel())` instead of direct boolean checks
- **DashScopeChatModel.java**: Change `multiModel` type from primitive `boolean` to `Boolean` wrapper to support null values

## Impact

With this change, when `multiModel` is `null` (not explicitly set), `ModelOptionsUtils.merge()` will use the value from `defaultOptions` instead of overriding it with `false`.

Fix: https://github.com/alibaba/spring-ai-alibaba/issues/4408