### PR TITLE
fix: remove default values from Boolean options to prevent override during merge

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -519,7 +519,7 @@ public class DashScopeApi {
 		Assert.notNull(additionalHttpHeader, "The additional HTTP headers can not be null.");
 
 		var chatCompletionUri = this.completionsPath;
-		if (chatRequest.multiModel()) {
+		if (Boolean.TRUE.equals(chatRequest.multiModel())) {
 			chatCompletionUri = MULTIMODAL_GENERATION_RESTFUL_URL;
 		}
 
@@ -575,7 +575,7 @@ public class DashScopeApi {
 				incrementalOutput);
 
 		var chatCompletionUri = this.completionsPath;
-		if (chatRequest.multiModel()) {
+		if (Boolean.TRUE.equals(chatRequest.multiModel())) {
 			chatCompletionUri = MULTIMODAL_GENERATION_RESTFUL_URL;
 		}
 

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -578,7 +578,7 @@ public class DashScopeChatModel implements ChatModel {
 			requestOptions.setTools(getFunctionTools(toolDefinitions));
 		}
 
-		boolean multiModel = requestOptions.getMultiModel();
+		Boolean multiModel = requestOptions.getMultiModel();
 
 		return new ChatCompletionRequest(requestOptions.getModel(),
 				new ChatCompletionRequestInput(chatCompletionMessages),

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
@@ -120,7 +120,7 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
      *   <li>false (default): Disable internet search.
      * </ul>
      */
-    private @JsonProperty("enable_search") Boolean enableSearch = false;
+    private @JsonProperty("enable_search") Boolean enableSearch;
 
     /**
      * Models can specify the format of the returned content. Valid values: {"type": "text"} or {"type": "json_object"}
@@ -141,7 +141,7 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
      * will not include the previously output content. You need to concatenate the overall output yourself.
      * When set to false, the subsequent output will include the previously output content.
      */
-    private @JsonProperty("incremental_output") Boolean incrementalOutput = true;
+    private @JsonProperty("incremental_output") Boolean incrementalOutput;
 
     /**
      * Used to control the repetition degree during model generation. Increasing the repetition_penalty
@@ -193,7 +193,7 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
     /**
      * Whether to enable the thinking process of the model.
      */
-    private @JsonProperty("enable_thinking") Boolean enableThinking = false;
+    private @JsonProperty("enable_thinking") Boolean enableThinking;
 
     /**
      * The maximum length of the thinking process takes effect when enable_thinking is true,
@@ -222,12 +222,12 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
     /**
      * Indicates whether the request involves multiple models
      */
-    private @JsonProperty("multi_model") Boolean multiModel = false;
+    private @JsonProperty("multi_model") Boolean multiModel;
 
     /**
      * Whether to enable the vision language model to output image height and width.
      */
-    private Boolean vlEnableImageHwOutput = false;
+    private Boolean vlEnableImageHwOutput;
 
     /**
      * The tone color and format of the output audio are only applicable to the 'Qwen-Omni' model,


### PR DESCRIPTION
## Summary

Fixes issue where user-configured Boolean options were being overridden by hardcoded default values during options merging in the Agent framework.

## Problem

When configuring options like `multiModel(true)`, `enableSearch(true)`, `enableThinking(true)`, etc., these settings were being overridden during the options merging process. This caused:
- Wrong endpoint routing (multiModel)
- Lost user configurations (other Boolean options)

**Root Cause**: 
The affected Boolean fields had hardcoded default values (`= false` or `= true`). During `ModelOptionsUtils.merge()` operations, non-null values from runtime options would override values from `defaultOptions`, even when users had explicitly configured them.

## Changes

### DashScopeChatOptions.java
Removed default values from 5 Boolean fields:
- `multiModel` (was `= false`)
- `enableSearch` (was `= false`)
- `incrementalOutput` (was `= true`)
- `enableThinking` (was `= false`)
- `vlEnableImageHwOutput` (was `= false`)

### DashScopeApi.java
Added null-safe checks for `multiModel`:
- Changed `if (chatRequest.multiModel())` to `if (Boolean.TRUE.equals(chatRequest.multiModel()))`
- Applied to both `chatCompletionEntity()` and `chatCompletionStream()` methods

### DashScopeChatModel.java
- Changed `multiModel` type from primitive `boolean` to `Boolean` wrapper to support null values

## Impact

**Positive**:
- User-configured Boolean options are now properly preserved during options merging
- Fixes the bug reported in Issue #4408 for all affected Boolean fields
- No breaking changes for existing code that explicitly sets these options

**Note**:
- Fields without `@JsonIgnore` (enableSearch, incrementalOutput, etc.) are serialized to JSON
- Null values are not serialized due to `@JsonInclude(NON_NULL)`
- DashScope API uses its own defaults when these fields are null
- The `multiModel` field uses `@JsonIgnore` and is only used internally for endpoint routing

## Testing

The fix allows these fields to be null when not explicitly set, enabling `ModelOptionsUtils.merge()` to use values from `defaultOptions` instead of overriding them with hardcoded defaults.

Ref: https://github.com/alibaba/spring-ai-alibaba/issues/4408