### PR TITLE
fix: remove default value from multiModel to prevent override during options merge

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -519,7 +519,7 @@ public class DashScopeApi {
 		Assert.notNull(additionalHttpHeader, "The additional HTTP headers can not be null.");
 
 		var chatCompletionUri = this.completionsPath;
-		if (chatRequest.multiModel()) {
+		if (Boolean.TRUE.equals(chatRequest.multiModel())) {
 			chatCompletionUri = MULTIMODAL_GENERATION_RESTFUL_URL;
 		}
 
@@ -575,7 +575,7 @@ public class DashScopeApi {
 				incrementalOutput);
 
 		var chatCompletionUri = this.completionsPath;
-		if (chatRequest.multiModel()) {
+		if (Boolean.TRUE.equals(chatRequest.multiModel())) {
 			chatCompletionUri = MULTIMODAL_GENERATION_RESTFUL_URL;
 		}
 

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -578,7 +578,7 @@ public class DashScopeChatModel implements ChatModel {
 			requestOptions.setTools(getFunctionTools(toolDefinitions));
 		}
 
-		boolean multiModel = requestOptions.getMultiModel();
+		Boolean multiModel = requestOptions.getMultiModel();
 
 		return new ChatCompletionRequest(requestOptions.getModel(),
 				new ChatCompletionRequestInput(chatCompletionMessages),

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
@@ -222,7 +222,7 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
     /**
      * Indicates whether the request involves multiple models
      */
-    private @JsonProperty("multi_model") Boolean multiModel = false;
+    private @JsonProperty("multi_model") Boolean multiModel;
 
     /**
      * Whether to enable the vision language model to output image height and width.


### PR DESCRIPTION
## Summary

Fixes issue where `multiModel=true` configuration was being overridden by the default `false` value during options merging in the Agent framework.

## Problem

When configuring a multimodal model (e.g., qwen3.5-plus, kimi-k2.5) with `DashScopeChatOptions.builder().multiModel(true)`, the setting was being overridden during the options merging process, causing requests to route to the wrong endpoint (`text-generation` instead of `multimodal-generation`).

**Root Cause**: 
The `multiModel` field had a default value of `false`, which was not `null`. During `ModelOptionsUtils.merge()` operations, non-null values from runtime options would override values from `defaultOptions`, even when users had explicitly configured them.

## Changes

### DashScopeChatOptions.java
- **Only**: Removed default value from `multiModel` field
  - Before: `private Boolean multiModel = false;`
  - After: `private Boolean multiModel;`

### DashScopeApi.java
Added null-safe checks for `multiModel`:
- Changed `if (chatRequest.multiModel())` to `if (Boolean.TRUE.equals(chatRequest.multiModel()))`
- Applied to both `chatCompletionEntity()` and `chatCompletionStream()` methods

### DashScopeChatModel.java
- Changed `multiModel` type from primitive `boolean` to `Boolean` wrapper to support null values

## Why Only multiModel?

**Key Difference Between Fields**:

| Field | @JsonIgnore? | Purpose | Should Remove Default? |
|-------|--------------|---------|------------------------|
| `multiModel` | ✅ Yes | **Internal routing only** (not sent to API) | ✅ **Yes** - causes wrong endpoint |
| `enableSearch` | ❌ No | **API parameter** (sent to DashScope) | ❌ No - API handles it |
| `incrementalOutput` | ❌ No | **API parameter** (sent to DashScope) | ❌ No - API handles it |
| `enableThinking` | ❌ No | **API parameter** (sent to DashScope) | ❌ No - API handles it |
| `vlEnableImageHwOutput` | ❌ No | **API parameter** (sent to DashScope) | ❌ No - API handles it |

**Reasoning**:
- `multiModel` has `@JsonIgnore` annotation - it's **never serialized to JSON**
- It's only used **internally** to decide which endpoint to route the request to
- When it's wrong, requests go to the completely wrong endpoint (hard error)
- Other fields are **API parameters** sent to DashScope, which has its own defaults

**For API parameters** (enableSearch, incrementalOutput, etc.):
- They are serialized to JSON with `@JsonProperty`
- When `null`, Jackson doesn't serialize them (due to `@JsonInclude(NON_NULL)`)
- DashScope API uses its own defaults when these fields are absent
- Removing their defaults would change the API contract without clear benefit

## Impact

**Positive**:
- Fixes the specific bug reported in Issue #4408
- User-configured `multiModel` setting is now properly preserved during options merging
- Minimal change scope reduces risk

**No Breaking Changes**:
- Other Boolean fields retain their default values
- API parameters continue to work as before
- Backward compatible with existing code

Ref: https://github.com/alibaba/spring-ai-alibaba/issues/4408