### PR TITLE
fix: apply mcpTraceExchangeFilterFunction correctly in distributed WebFlux MCP clients

### DIFF
--- a/mcp/spring-ai-alibaba-mcp-distributed/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/sse/SseWebFluxDistributedAsyncMcpClient.java
+++ b/mcp/spring-ai-alibaba-mcp-distributed/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/sse/SseWebFluxDistributedAsyncMcpClient.java
@@ -188,9 +188,9 @@ public class SseWebFluxDistributedAsyncMcpClient implements DistributedAsyncMcpC
 
         WebFluxSseClientTransport transport;
         if (traceFilter != null) {
-            transport = WebFluxSseClientTransportBuilder.build(webClientBuilder, mcpJsonMapper, exportPath);
-        } else {
             transport = WebFluxSseClientTransportBuilder.build(webClientBuilder, mcpJsonMapper, exportPath, traceFilter);
+        } else {
+            transport = WebFluxSseClientTransportBuilder.build(webClientBuilder, mcpJsonMapper, exportPath);
         }
 
         NamedClientMcpTransport namedClientMcpTransport = new NamedClientMcpTransport(

--- a/mcp/spring-ai-alibaba-mcp-distributed/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/sse/SseWebFluxDistributedSyncMcpClient.java
+++ b/mcp/spring-ai-alibaba-mcp-distributed/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/sse/SseWebFluxDistributedSyncMcpClient.java
@@ -182,9 +182,9 @@ public class SseWebFluxDistributedSyncMcpClient implements DistributedSyncMcpCli
 
         WebFluxSseClientTransport transport;
         if (traceFilter != null) {
-            transport = WebFluxSseClientTransportBuilder.build(webClientBuilder, mcpJsonMapper, exportPath);
-        } else {
             transport = WebFluxSseClientTransportBuilder.build(webClientBuilder, mcpJsonMapper, exportPath, traceFilter);
+        } else {
+            transport = WebFluxSseClientTransportBuilder.build(webClientBuilder, mcpJsonMapper, exportPath);
         }
 
         NamedClientMcpTransport namedClientMcpTransport = new NamedClientMcpTransport(

--- a/mcp/spring-ai-alibaba-mcp-distributed/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/streamable/StreamWebFluxDistributedAsyncMcpClient.java
+++ b/mcp/spring-ai-alibaba-mcp-distributed/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/streamable/StreamWebFluxDistributedAsyncMcpClient.java
@@ -185,9 +185,9 @@ public class StreamWebFluxDistributedAsyncMcpClient implements DistributedAsyncM
 
         WebClientStreamableHttpTransport transport;
         if (traceFilter != null) {
-            transport = WebFluxStreamableClientTransportBuilder.build(webClientBuilder, mcpJsonMapper, exportPath);
-        } else {
             transport = WebFluxStreamableClientTransportBuilder.build(webClientBuilder, mcpJsonMapper, exportPath, traceFilter);
+        } else {
+            transport = WebFluxStreamableClientTransportBuilder.build(webClientBuilder, mcpJsonMapper, exportPath);
         }
 
         NamedClientMcpTransport namedClientMcpTransport = new NamedClientMcpTransport(

--- a/mcp/spring-ai-alibaba-mcp-distributed/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/streamable/StreamWebFluxDistributedSyncMcpClient.java
+++ b/mcp/spring-ai-alibaba-mcp-distributed/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/streamable/StreamWebFluxDistributedSyncMcpClient.java
@@ -183,9 +183,9 @@ public class StreamWebFluxDistributedSyncMcpClient implements DistributedSyncMcp
 
         WebClientStreamableHttpTransport transport;
         if (traceFilter != null) {
-            transport = WebFluxStreamableClientTransportBuilder.build(webClientBuilder, mcpJsonMapper, exportPath);
-        } else {
             transport = WebFluxStreamableClientTransportBuilder.build(webClientBuilder, mcpJsonMapper, exportPath, traceFilter);
+        } else {
+            transport = WebFluxStreamableClientTransportBuilder.build(webClientBuilder, mcpJsonMapper, exportPath);
         }
 
         NamedClientMcpTransport namedClientMcpTransport = new NamedClientMcpTransport(


### PR DESCRIPTION
Fixes #202

## Summary

This PR fixes an issue where `mcpTraceExchangeFilterFunction` was discovered from the Spring context but was not actually attached to the underlying WebFlux MCP client transport.

## Root Cause

In `clientByEndpoint(...)`, the `traceFilter` branch logic was reversed:

- when `traceFilter != null`, the code used the builder method without the filter
- when `traceFilter == null`, the code used the overload with the filter parameter, but passed `null`

As a result, `mcpTraceExchangeFilterFunction` was never applied in practice.

This affected features built on top of `ExchangeFilterFunction`, such as:

- request header propagation
- custom tracing
- client-side request interception

## Fix

The logic is updated so that:

- when `traceFilter != null`, the transport is built with the overload that accepts `traceFilter`
- when `traceFilter == null`, the transport is built with the default overload

## Scope

This fix is applied to:

- `StreamWebFluxDistributedAsyncMcpClient`
- `StreamWebFluxDistributedSyncMcpClient`
- `SseWebFluxDistributedAsyncMcpClient`
- `SseWebFluxDistributedSyncMcpClient`

## Testing

- verified the branch logic locally
- confirmed that when `traceFilter` is present, the transport now uses the builder overload that attaches the filter
- confirmed that custom `mcpTraceExchangeFilterFunction` can participate in the request chain as expected
