### PR TITLE
feat(model): Support image-out-painting for DashScope model

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeImageApi.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeImageApi.java
@@ -42,8 +42,10 @@ import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.HEADER
 import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.IMAGE2IMAGE_RESTFUL_URL;
 import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.IMAGE_GENERATION_RESTFUL_URL;
 import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.MULTIMODAL_GENERATION_RESTFUL_URL;
+import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.OUT_PAINTING_RESTFUL_URL;
 import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.QUERY_TASK_RESTFUL_URL;
 import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.TEXT2IMAGE_RESTFUL_URL;
+import static com.alibaba.cloud.ai.dashscope.spec.DashScopeModel.ImageModel.IMAGE_OUT_PAINTING;
 import static com.alibaba.cloud.ai.dashscope.spec.DashScopeModel.ImageModel.QWEN_IMAGE;
 import static com.alibaba.cloud.ai.dashscope.spec.DashScopeModel.ImageModel.QWEN_MT_IMAGE;
 import static com.alibaba.cloud.ai.dashscope.spec.DashScopeModel.ImageModel.WAN_2_6_IMAGE;
@@ -61,6 +63,8 @@ import static com.alibaba.cloud.ai.dashscope.spec.DashScopeModel.ImageModel.WAN_
  *   wan2.5-t2i-preview, wan2.2-t2i-*, wanx2.1-t2i-*, wanx2.0-t2i-turbo, wanx-v1 (Wanx text-to-image V2 legacy)</li>
  *   <li>{@value com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants#IMAGE2IMAGE_RESTFUL_URL}:
  *   qwen-mt-image (Qwen image translation)</li>
+ *   <li>{@value com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants#OUT_PAINTING_RESTFUL_URL}:
+ *   image-out-painting (AI image out-painting)</li>
  * </ul>
  *
  * @author nuocheng.lxm
@@ -118,9 +122,9 @@ public class DashScopeImageApi {
 
 		this.restClient = restClientBuilder.clone()
             .baseUrl(baseUrl)
-			.defaultHeaders(ApiUtils.getJsonContentHeaders(apiKey.getValue(), workSpaceId))
-			.defaultStatusHandler(responseErrorHandler)
-			.build();
+				.defaultHeaders(ApiUtils.getJsonContentHeaders(apiKey.getValue(), workSpaceId))
+				.defaultStatusHandler(responseErrorHandler)
+				.build();
 	}
 
 	public ResponseEntity<DashScopeApiSpec.DashScopeImageAsyncResponse> submitImageGenTask(DashScopeApiSpec.DashScopeImageRequest request, boolean needsAsync) {
@@ -128,7 +132,11 @@ public class DashScopeImageApi {
 		String model = request.model();
 		ImageApiPath path = resolveImagePath(model);
 		String imagesUri = path.uri;
-		Object requestBody = path.needImageGenerationBody ? convertToImageGenerationRequest(request) : request;
+		Object requestBody = switch (path.bodyType) {
+			case IMAGE_GENERATION -> convertToImageGenerationRequest(request);
+			case OUT_PAINTING -> convertToOutPaintingRequest(request);
+			default -> request;
+		};
 
 		var requestBuilder = this.restClient.post()
 			.uri(imagesUri)
@@ -150,18 +158,22 @@ public class DashScopeImageApi {
 	private ImageApiPath resolveImagePath(String model) {
 		// wan2.6-image: Wanx 2.6 async -> image-generation/generation + dedicated request body
 		if (WAN_2_6_IMAGE.getValue().equals(model)) {
-			return new ImageApiPath(IMAGE_GENERATION_RESTFUL_URL, true);
+			return new ImageApiPath(IMAGE_GENERATION_RESTFUL_URL, RequestBodyType.IMAGE_GENERATION);
+		}
+		// image-out-painting: AI out-painting -> image2image/out-painting
+		if (IMAGE_OUT_PAINTING.getValue().equals(model)) {
+			return new ImageApiPath(OUT_PAINTING_RESTFUL_URL, RequestBodyType.OUT_PAINTING);
 		}
 		// qwen-mt-image: Qwen image translation -> image2image/image-synthesis
 		if (QWEN_MT_IMAGE.getValue().equals(model)) {
-			return new ImageApiPath(IMAGE2IMAGE_RESTFUL_URL, false);
+			return new ImageApiPath(IMAGE2IMAGE_RESTFUL_URL, RequestBodyType.STANDARD);
 		}
 		// qwen-image*, z-image* (incl. qwen-image-edit*): Qwen text-to-image/edit, Z-Image -> multimodal-generation/generation
 		if (model.startsWith("qwen-image") || model.startsWith("z-image")) {
-			return new ImageApiPath(MULTIMODAL_GENERATION_RESTFUL_URL, false);
+			return new ImageApiPath(MULTIMODAL_GENERATION_RESTFUL_URL, RequestBodyType.STANDARD);
 		}
 		// Wanx 2.5 and below, wanx series: text2image/image-synthesis
-		return new ImageApiPath(this.imagesPath, false);
+		return new ImageApiPath(this.imagesPath, RequestBodyType.STANDARD);
 	}
 
 	/**
@@ -176,13 +188,15 @@ public class DashScopeImageApi {
 			   model.equals("wanx2.1-imageedit");
 	}
 
+	enum RequestBodyType { STANDARD, IMAGE_GENERATION, OUT_PAINTING }
+
 	private static final class ImageApiPath {
 		final String uri;
-		final boolean needImageGenerationBody;
+		final RequestBodyType bodyType;
 
-		ImageApiPath(String uri, boolean needImageGenerationBody) {
+		ImageApiPath(String uri, RequestBodyType bodyType) {
 			this.uri = uri;
-			this.needImageGenerationBody = needImageGenerationBody;
+			this.bodyType = bodyType;
 		}
 	}
 
@@ -203,6 +217,24 @@ public class DashScopeImageApi {
                         request.parameters().promptExtend(),
                         request.parameters().watermark()
                 ));
+    }
+
+    private DashScopeApiSpec.DashScopeOutPaintingRequest convertToOutPaintingRequest(DashScopeImageRequest request) {
+        return new DashScopeApiSpec.DashScopeOutPaintingRequest(
+                request.model(),
+                new DashScopeApiSpec.DashScopeOutPaintingRequest.DashScopeOutPaintingRequestInput(
+                        request.input().baseImageUrl()),
+                new DashScopeApiSpec.DashScopeOutPaintingRequest.DashScopeOutPaintingRequestParameter(
+                        request.parameters().outputRatio(),
+                        request.parameters().xScale(),
+                        request.parameters().yScale(),
+                        request.parameters().angle(),
+                        request.parameters().leftOffset(),
+                        request.parameters().rightOffset(),
+                        request.parameters().topOffset(),
+                        request.parameters().bottomOffset(),
+                        request.parameters().bestQuality(),
+                        request.parameters().limitImageSize()));
     }
 
     @NonNull

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/common/DashScopeApiConstants.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/common/DashScopeApiConstants.java
@@ -62,6 +62,8 @@ public final class DashScopeApiConstants {
 
 	public static final String IMAGE_GENERATION_RESTFUL_URL = "/api/v1/services/aigc/image-generation/generation";
 
+	public static final String OUT_PAINTING_RESTFUL_URL = "/api/v1/services/aigc/image2image/out-painting";
+
 	public static final String AUDIO_TRANSCRIPTION_RESTFUL_URL = "/api/v1/services/audio/asr/transcription";
 
 	public static final String TEXT_RERANK_RESTFUL_URL = "/api/v1/services/rerank/text-rerank/text-rerank";

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/image/DashScopeImageModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/image/DashScopeImageModel.java
@@ -374,11 +374,15 @@ public class DashScopeImageModel implements ImageModel {
     private ImageResponse toImageResponse(DashScopeApiSpec.DashScopeImageAsyncResponse asyncResp) {
         var output = asyncResp.output();
         var results = output.results();
+        String outputImageUrl = output.outputImageUrl();
         List<DashScopeImageAsyncResponseChoice> choices = output.choices();
         List<ImageGeneration> gens = new ArrayList<>();
         ImageResponseMetadata md = toMetadata(asyncResp);
         if (results != null) {
             gens = results.stream().map(r -> new ImageGeneration(new Image(r.url(), null))).collect(Collectors.toList());
+        }
+        if (outputImageUrl != null && !outputImageUrl.isEmpty()) {
+            gens.add(new ImageGeneration(new Image(outputImageUrl, null)));
         }
         if (choices != null) {
             for (DashScopeImageAsyncResponseChoice choice : choices) {
@@ -423,7 +427,17 @@ public class DashScopeImageModel implements ImageModel {
                         options.getMaskColor(),
                         options.getNegativePrompt(),
                         options.getMaxImages(),
-                        options.getEnableInterleave()));
+                        options.getEnableInterleave(),
+                        options.getOutputRatio(),
+                        options.getXScale(),
+                        options.getYScale(),
+                        options.getAngle(),
+                        options.getLeftOffset(),
+                        options.getRightOffset(),
+                        options.getTopOffset(),
+                        options.getBottomOffset(),
+                        options.getBestQuality(),
+                        options.getLimitImageSize()));
     }
 
     private ImageResponseMetadata toMetadata(DashScopeApiSpec.DashScopeImageAsyncResponse re) {

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/image/DashScopeImageOptions.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/image/DashScopeImageOptions.java
@@ -127,6 +127,46 @@ public class DashScopeImageOptions implements ImageOptions {
   @JsonIgnore
   private InvokeMode invokeMode = InvokeMode.AUTO;
 
+  /** Output aspect ratio for out-painting, e.g. "4:3". */
+  @JsonProperty("output_ratio")
+  private String outputRatio;
+
+  /** Horizontal expansion scale for out-painting. */
+  @JsonProperty("x_scale")
+  private Float xScale;
+
+  /** Vertical expansion scale for out-painting. */
+  @JsonProperty("y_scale")
+  private Float yScale;
+
+  /** Rotation angle in degrees for out-painting. */
+  @JsonProperty("angle")
+  private Integer angle;
+
+  /** Left expansion in pixels for out-painting. */
+  @JsonProperty("left_offset")
+  private Integer leftOffset;
+
+  /** Right expansion in pixels for out-painting. */
+  @JsonProperty("right_offset")
+  private Integer rightOffset;
+
+  /** Top expansion in pixels for out-painting. */
+  @JsonProperty("top_offset")
+  private Integer topOffset;
+
+  /** Bottom expansion in pixels for out-painting. */
+  @JsonProperty("bottom_offset")
+  private Integer bottomOffset;
+
+  /** Whether to use best quality mode for out-painting. */
+  @JsonProperty("best_quality")
+  private Boolean bestQuality;
+
+  /** Whether to limit output image size for out-painting. */
+  @JsonProperty("limit_image_size")
+  private Boolean limitImageSize;
+
   public Boolean getPromptExtend() {
     return promptExtend;
   }
@@ -229,6 +269,86 @@ public class DashScopeImageOptions implements ImageOptions {
 
   public void setInvokeMode(InvokeMode invokeMode) {
     this.invokeMode = invokeMode;
+  }
+
+  public String getOutputRatio() {
+    return outputRatio;
+  }
+
+  public void setOutputRatio(String outputRatio) {
+    this.outputRatio = outputRatio;
+  }
+
+  public Float getXScale() {
+    return xScale;
+  }
+
+  public void setXScale(Float xScale) {
+    this.xScale = xScale;
+  }
+
+  public Float getYScale() {
+    return yScale;
+  }
+
+  public void setYScale(Float yScale) {
+    this.yScale = yScale;
+  }
+
+  public Integer getAngle() {
+    return angle;
+  }
+
+  public void setAngle(Integer angle) {
+    this.angle = angle;
+  }
+
+  public Integer getLeftOffset() {
+    return leftOffset;
+  }
+
+  public void setLeftOffset(Integer leftOffset) {
+    this.leftOffset = leftOffset;
+  }
+
+  public Integer getRightOffset() {
+    return rightOffset;
+  }
+
+  public void setRightOffset(Integer rightOffset) {
+    this.rightOffset = rightOffset;
+  }
+
+  public Integer getTopOffset() {
+    return topOffset;
+  }
+
+  public void setTopOffset(Integer topOffset) {
+    this.topOffset = topOffset;
+  }
+
+  public Integer getBottomOffset() {
+    return bottomOffset;
+  }
+
+  public void setBottomOffset(Integer bottomOffset) {
+    this.bottomOffset = bottomOffset;
+  }
+
+  public Boolean getBestQuality() {
+    return bestQuality;
+  }
+
+  public void setBestQuality(Boolean bestQuality) {
+    this.bestQuality = bestQuality;
+  }
+
+  public Boolean getLimitImageSize() {
+    return limitImageSize;
+  }
+
+  public void setLimitImageSize(Boolean limitImageSize) {
+    this.limitImageSize = limitImageSize;
   }
 
   public static Builder builder() {
@@ -351,7 +471,11 @@ public class DashScopeImageOptions implements ImageOptions {
         + this.maskImageUrl + '\'' + ", sketchImageUrl='" + this.sketchImageUrl + '\'' + ", sketchWeight="
         + this.sketchWeight + ", sketchExtraction=" + this.sketchExtraction + ", sketchColor="
         + Arrays.toString(this.sketchColor) + ", maskColor=" + Arrays.toString(this.maskColor) + ", maxImages="
-        + this.maxImages + ", enableInterleave=" + this.enableInterleave + ", invokeMode=" + this.invokeMode + '}';
+        + this.maxImages + ", enableInterleave=" + this.enableInterleave + ", invokeMode=" + this.invokeMode
+        + ", outputRatio='" + this.outputRatio + '\''
+        + ", xScale=" + this.xScale + ", yScale=" + this.yScale + ", angle=" + this.angle + ", leftOffset="
+        + this.leftOffset + ", rightOffset=" + this.rightOffset + ", topOffset=" + this.topOffset + ", bottomOffset="
+        + this.bottomOffset + ", bestQuality=" + this.bestQuality + ", limitImageSize=" + this.limitImageSize + '}';
   }
 
   public static class Builder {
@@ -601,6 +725,106 @@ public class DashScopeImageOptions implements ImageOptions {
     public Builder invokeMode(InvokeMode invokeMode) {
         this.options.invokeMode = invokeMode;
         return this;
+    }
+
+    public Builder outputRatio(String outputRatio) {
+        this.options.outputRatio = outputRatio;
+        return this;
+    }
+
+    @Deprecated
+    public Builder withOutputRatio(String outputRatio) {
+        return outputRatio(outputRatio);
+    }
+
+    public Builder xScale(Float xScale) {
+        this.options.xScale = xScale;
+        return this;
+    }
+
+    @Deprecated
+    public Builder withXScale(Float xScale) {
+        return xScale(xScale);
+    }
+
+    public Builder yScale(Float yScale) {
+        this.options.yScale = yScale;
+        return this;
+    }
+
+    @Deprecated
+    public Builder withYScale(Float yScale) {
+        return yScale(yScale);
+    }
+
+    public Builder angle(Integer angle) {
+        this.options.angle = angle;
+        return this;
+    }
+
+    @Deprecated
+    public Builder withAngle(Integer angle) {
+        return angle(angle);
+    }
+
+    public Builder leftOffset(Integer leftOffset) {
+        this.options.leftOffset = leftOffset;
+        return this;
+    }
+
+    @Deprecated
+    public Builder withLeftOffset(Integer leftOffset) {
+        return leftOffset(leftOffset);
+    }
+
+    public Builder rightOffset(Integer rightOffset) {
+        this.options.rightOffset = rightOffset;
+        return this;
+    }
+
+    @Deprecated
+    public Builder withRightOffset(Integer rightOffset) {
+        return rightOffset(rightOffset);
+    }
+
+    public Builder topOffset(Integer topOffset) {
+        this.options.topOffset = topOffset;
+        return this;
+    }
+
+    @Deprecated
+    public Builder withTopOffset(Integer topOffset) {
+        return topOffset(topOffset);
+    }
+
+    public Builder bottomOffset(Integer bottomOffset) {
+        this.options.bottomOffset = bottomOffset;
+        return this;
+    }
+
+    @Deprecated
+    public Builder withBottomOffset(Integer bottomOffset) {
+        return bottomOffset(bottomOffset);
+    }
+
+    public Builder bestQuality(Boolean bestQuality) {
+        this.options.bestQuality = bestQuality;
+        return this;
+    }
+
+    @Deprecated
+    public Builder withBestQuality(Boolean bestQuality) {
+        return bestQuality(bestQuality);
+    }
+
+    public Builder limitImageSize(Boolean limitImageSize) {
+        this.options.limitImageSize = limitImageSize;
+        return this;
+    }
+
+    @Deprecated
+    public Builder withLimitImageSize(Boolean limitImageSize) {
+        return limitImageSize(limitImageSize);
     }
 
     public DashScopeImageOptions build() {

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
@@ -1396,7 +1396,17 @@ public class DashScopeApiSpec {
                                                      @JsonProperty("mask_color") Integer[][] maskColor,
                                                      @JsonProperty("negative_prompt") String negativePrompt,
                                                      @JsonProperty("max_images") Integer maxImages,
-                                                     @JsonProperty("enable_interleave") Boolean enableInterleave){
+                                                     @JsonProperty("enable_interleave") Boolean enableInterleave,
+                                                     @JsonProperty("output_ratio") String outputRatio,
+                                                     @JsonProperty("x_scale") Float xScale,
+                                                     @JsonProperty("y_scale") Float yScale,
+                                                     @JsonProperty("angle") Integer angle,
+                                                     @JsonProperty("left_offset") Integer leftOffset,
+                                                     @JsonProperty("right_offset") Integer rightOffset,
+                                                     @JsonProperty("top_offset") Integer topOffset,
+                                                     @JsonProperty("bottom_offset") Integer bottomOffset,
+                                                     @JsonProperty("best_quality") Boolean bestQuality,
+                                                     @JsonProperty("limit_image_size") Boolean limitImageSize){
         }
     }
 
@@ -1429,6 +1439,29 @@ public class DashScopeApiSpec {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record DashScopeOutPaintingRequest(@JsonProperty("model") String model,
+                                              @JsonProperty("input") DashScopeOutPaintingRequestInput input,
+                                              @JsonProperty("parameters") DashScopeOutPaintingRequestParameter parameters
+    ) {
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public record DashScopeOutPaintingRequestInput(@JsonProperty("image_url") String imageUrl) {
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public record DashScopeOutPaintingRequestParameter(@JsonProperty("output_ratio") String outputRatio,
+                                                           @JsonProperty("x_scale") Float xScale,
+                                                           @JsonProperty("y_scale") Float yScale,
+                                                           @JsonProperty("angle") Integer angle,
+                                                           @JsonProperty("left_offset") Integer leftOffset,
+                                                           @JsonProperty("right_offset") Integer rightOffset,
+                                                           @JsonProperty("top_offset") Integer topOffset,
+                                                           @JsonProperty("bottom_offset") Integer bottomOffset,
+                                                           @JsonProperty("best_quality") Boolean bestQuality,
+                                                           @JsonProperty("limit_image_size") Boolean limitImageSize) {
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public record DashScopeImageAsyncResponse(@JsonProperty("request_id") String requestId,
                                               @JsonProperty("output") DashScopeImageAsyncResponseOutput output,
                                               @JsonProperty("usage") DashScopeImageAsyncResponseUsage usage) {
@@ -1440,6 +1473,7 @@ public class DashScopeApiSpec {
                                                         @JsonProperty("scheduled_time") String scheduledTime,
                                                         @JsonProperty("end_time") String endTime,
                                                         @JsonProperty("results") List<DashScopeImageAsyncResponseResult> results,
+                                                        @JsonProperty("output_image_url") String outputImageUrl,
                                                         @JsonProperty("choices") List<DashScopeImageAsyncResponseChoice> choices,
                                                         @JsonProperty("task_metrics") DashScopeImageAsyncResponseTaskMetrics taskMetrics,
                                                         @JsonProperty("code") String code, @JsonProperty("message") String message) {

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeModel.java
@@ -436,7 +436,9 @@ public class DashScopeModel {
 
         WAN_2_5_I_2_I_PREVIEW("wan2.2-t2i-preview"),
 
-        WAN_2_6_IMAGE("wan2.6-image");
+        WAN_2_6_IMAGE("wan2.6-image"),
+
+        IMAGE_OUT_PAINTING("image-out-painting");
 
         public final String value;
 

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeImageApiTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeImageApiTests.java
@@ -116,7 +116,8 @@ class DashScopeImageApiTests {
 		Integer[][] colorArray = { { 0, 0, 0 }, { 134, 134, 134 } };
 
         DashScopeApiSpec.DashScopeImageRequest.DashScopeImageRequestParameter parameter = new DashScopeApiSpec.DashScopeImageRequest.DashScopeImageRequestParameter(
-				"anime", "1024*1024", 1, 123456, 0.5f, "canny", true, true, 5, true, colorArray, colorArray,"",1,false);
+				"anime", "1024*1024", 1, 123456, 0.5f, "canny", true, true, 5, true, colorArray, colorArray,"",1,false,
+					null, null, null, null, null, null, null, null, null, null);
 
         DashScopeApiSpec.DashScopeImageRequest request = new DashScopeApiSpec.DashScopeImageRequest(
 				"stable-diffusion-xl", input, parameter);
@@ -148,7 +149,7 @@ class DashScopeImageApiTests {
 				1, 1, 0);
 
         DashScopeApiSpec.DashScopeImageAsyncResponse.DashScopeImageAsyncResponseOutput output = new DashScopeApiSpec.DashScopeImageAsyncResponse.DashScopeImageAsyncResponseOutput(
-                "task-id", "completed", null, null, null, results, null, metrics, "200", "success");
+                "task-id", "completed", null, null, null, results, null, null, metrics, "200", "success");
 
         DashScopeApiSpec.DashScopeImageAsyncResponse.DashScopeImageAsyncResponseUsage usage = new DashScopeApiSpec.DashScopeImageAsyncResponse.DashScopeImageAsyncResponseUsage(
 				1);

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/image/DashScopeImageModelTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/image/DashScopeImageModelTests.java
@@ -149,7 +149,7 @@ class DashScopeImageModelTests {
 	private void mockSuccessfulImageGeneration() {
 		// Mock successful task submission
         DashScopeImageAsyncResponse submitResponse = new DashScopeImageAsyncResponse(TEST_REQUEST_ID,
-                new DashScopeImageAsyncResponseOutput(TEST_TASK_ID, "PENDING", null, null, null, null, null, null, null, null),
+                new DashScopeImageAsyncResponseOutput(TEST_TASK_ID, "PENDING", null, null, null, null, null, null, null, null, null),
                 new DashScopeImageAsyncResponseUsage(1));
         when(dashScopeImageApi.submitImageGenTask(any(), anyBoolean())).thenReturn(ResponseEntity.ok(submitResponse));
 
@@ -157,7 +157,7 @@ class DashScopeImageModelTests {
 		// Mock successful task completion
         DashScopeImageAsyncResponse completedResponse = new DashScopeImageAsyncResponse(TEST_REQUEST_ID,
                 new DashScopeImageAsyncResponseOutput(TEST_TASK_ID, "SUCCEEDED",
-                        null, null, null, List.of(new DashScopeImageAsyncResponseResult(TEST_IMAGE_URL)), null, null, null, null),
+                        null, null, null, List.of(new DashScopeImageAsyncResponseResult(TEST_IMAGE_URL)), null, null, null, null, null),
                 new DashScopeImageAsyncResponseUsage(1));
         when(dashScopeImageApi.getImageGenTaskResult(TEST_TASK_ID)).thenReturn(ResponseEntity.ok(completedResponse));
     }
@@ -165,13 +165,13 @@ class DashScopeImageModelTests {
 	private void mockFailedImageGeneration() {
 		// Mock successful task submission but failed completion
 		DashScopeImageAsyncResponse submitResponse = new DashScopeImageAsyncResponse(TEST_REQUEST_ID,
-                new DashScopeImageAsyncResponseOutput(TEST_TASK_ID, "PENDING", null, null, null, null, null, null, null, null),
+                new DashScopeImageAsyncResponseOutput(TEST_TASK_ID, "PENDING", null, null, null, null, null, null, null, null, null),
                 new DashScopeImageAsyncResponseUsage(1));
 		when(dashScopeImageApi.submitImageGenTask(any(), anyBoolean())).thenReturn(ResponseEntity.ok(submitResponse));
 
 		// Mock failed task completion
 		DashScopeImageAsyncResponse failedResponse = new DashScopeImageAsyncResponse(TEST_REQUEST_ID,
-                new DashScopeImageAsyncResponseOutput(TEST_TASK_ID, "FAILED", null, null, null, null, null, null, "ERROR_CODE", "Error message"),
+                new DashScopeImageAsyncResponseOutput(TEST_TASK_ID, "FAILED", null, null, null, null, null, null, null, "ERROR_CODE", "Error message"),
                 new DashScopeImageAsyncResponseUsage(1));
 		when(dashScopeImageApi.getImageGenTaskResult(TEST_TASK_ID)).thenReturn(ResponseEntity.ok(failedResponse));
 	}
@@ -201,13 +201,13 @@ class DashScopeImageModelTests {
 	private void mockTimeoutImageGeneration() {
 		// Mock successful task submission but pending status until timeout
 		DashScopeImageAsyncResponse submitResponse = new DashScopeImageAsyncResponse(TEST_REQUEST_ID,
-                new DashScopeImageAsyncResponseOutput(TEST_TASK_ID, "PENDING", null, null, null, null, null, null, null, null),
+                new DashScopeImageAsyncResponseOutput(TEST_TASK_ID, "PENDING", null, null, null, null, null, null, null, null, null),
                 new DashScopeImageAsyncResponseUsage(1));
 		when(dashScopeImageApi.submitImageGenTask(any(), anyBoolean())).thenReturn(ResponseEntity.ok(submitResponse));
 
 		// Mock pending status for all status checks
 		DashScopeImageAsyncResponse pendingResponse = new DashScopeImageAsyncResponse(TEST_REQUEST_ID,
-                new DashScopeImageAsyncResponseOutput(TEST_TASK_ID, "PENDING", null, null, null, null, null, null, null, null),
+                new DashScopeImageAsyncResponseOutput(TEST_TASK_ID, "PENDING", null, null, null, null, null, null, null, null, null),
                 new DashScopeImageAsyncResponseUsage(1));
 		when(dashScopeImageApi.getImageGenTaskResult(TEST_TASK_ID)).thenReturn(ResponseEntity.ok(pendingResponse));
 	}
@@ -236,5 +236,66 @@ class DashScopeImageModelTests {
         assertThat(clone2).isNotNull();
         assertThat(mutate1).isNotNull();
         assertThat(mutate2).isNotNull();
+    }
+
+    @Test
+    void testOutPaintingImageGeneration() {
+        // Test out-painting with ratio-based expansion
+        DashScopeImageOptions outPaintingOptions = DashScopeImageOptions.builder()
+                .model("image-out-painting")
+                .baseImageUrl("https://example.com/original.jpg")
+                .outputRatio("4:3")
+                .bestQuality(false)
+                .limitImageSize(true)
+                .build();
+
+        mockSuccessfulImageGeneration();
+
+        ImagePrompt prompt = new ImagePrompt("expand this image", outPaintingOptions);
+        ImageResponse response = imageModel.call(prompt);
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResult().getOutput().getUrl()).isEqualTo(TEST_IMAGE_URL);
+    }
+
+    @Test
+    void testOutPaintingWithScaleParameters() {
+        // Test out-painting with scale-based expansion
+        DashScopeImageOptions outPaintingOptions = DashScopeImageOptions.builder()
+                .model("image-out-painting")
+                .baseImageUrl("https://example.com/original.jpg")
+                .xScale(1.5f)
+                .yScale(1.5f)
+                .angle(90)
+                .build();
+
+        mockSuccessfulImageGeneration();
+
+        ImagePrompt prompt = new ImagePrompt("expand this image", outPaintingOptions);
+        ImageResponse response = imageModel.call(prompt);
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResult().getOutput().getUrl()).isEqualTo(TEST_IMAGE_URL);
+    }
+
+    @Test
+    void testOutPaintingWithOffsetParameters() {
+        // Test out-painting with pixel-based expansion
+        DashScopeImageOptions outPaintingOptions = DashScopeImageOptions.builder()
+                .model("image-out-painting")
+                .baseImageUrl("https://example.com/original.jpg")
+                .leftOffset(546)
+                .rightOffset(960)
+                .topOffset(158)
+                .bottomOffset(939)
+                .build();
+
+        mockSuccessfulImageGeneration();
+
+        ImagePrompt prompt = new ImagePrompt("expand this image", outPaintingOptions);
+        ImageResponse response = imageModel.call(prompt);
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResult().getOutput().getUrl()).isEqualTo(TEST_IMAGE_URL);
     }
 }

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/image/observation/DashScopeImageModelObservationITests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/image/observation/DashScopeImageModelObservationITests.java
@@ -132,7 +132,7 @@ class DashScopeImageModelObservationTests {
 
     var output =
             new DashScopeImageAsyncResponseOutput(
-            "00001", "SUCCEEDED", null, null, null, List.of(fakeResult), null, null, "code", "msg");
+            "00001", "SUCCEEDED", null, null, null, List.of(fakeResult), null, null, null, "code", "msg");
 
 
     var response = new DashScopeImageAsyncResponse("req-test", output, null);


### PR DESCRIPTION
### Describe what this PR does / why we need it

Add DashScope `image-out-painting` model support for AI-powered image boundary expansion. The out-painting model allows expanding image borders with intelligent content filling, supporting multiple expansion modes: by aspect ratio, by scale factor, and by pixel offset.

### Does this pull request fix one issue?

Fixes #215

### Describe how you did it

- Added `IMAGE_OUT_PAINTING` enum value and `OUT_PAINTING_RESTFUL_URL` API path constant
- Added 10 out-painting parameters to `DashScopeImageOptions` (outputRatio, xScale, yScale, angle, leftOffset, rightOffset, topOffset, bottomOffset, bestQuality, limitImageSize)
- Created `DashScopeOutPaintingRequest` record in `DashScopeApiSpec` with `image_url` input field
- Added route resolution and request body conversion in `DashScopeImageApi`, following the same pattern as wan2.6-image
- Refactored `ImageApiPath` to use `RequestBodyType` enum instead of boolean flags for better extensibility
- Added `outputImageUrl` field to async response to handle the out-painting API's response format
- Added test coverage for all 3 expansion modes (ratio, scale, offset)

### Describe how to verify it

Run tests: `mvn test -pl models/dashscope -Dtest=DashScopeImageModelTests`

### Special notes for reviews

- The out-painting API only provides HTTP REST API, no official SDK
- The API uses `image_url` in input and `output_image_url` in response, handled by dedicated record and field
- Region restriction: only China mainland (Beijing) API Key supported