### PR TITLE
feat(mcp): upgrade MCP Java SDK to 0.14.0 and consolidate versions

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -165,8 +165,11 @@ DashScopeChatModel 支持：
 MCP 提供了一个标准化协议，用于管理和路由 AI 模型上下文。此扩展包括：
 
 - **MCP Common**: 模型上下文协议的核心抽象和工具
+- **MCP Gateway**: 统一的 MCP 服务网关，支持多协议和 OAuth 认证
 - **MCP Registry**: 用于发现和管理 MCP 服务的注册中心
 - **MCP Router**: 智能路由功能，用于在多个模型上下文之间分发请求
+
+**MCP SDK 版本**: 0.14.0
 
 **可用的 Starter：**
 - `spring-ai-alibaba-starter-mcp-registry`

--- a/README.md
+++ b/README.md
@@ -165,8 +165,11 @@ Speech-to-text transcription model that converts audio into text with high accur
 MCP provides a standardized protocol for managing and routing AI model contexts. This extension includes:
 
 - **MCP Common**: Core abstractions and utilities for Model Context Protocol
+- **MCP Gateway**: Unified MCP service gateway with multi-protocol and OAuth authentication support
 - **MCP Registry**: Service registry for discovering and managing MCP services
 - **MCP Router**: Intelligent routing capabilities for distributing requests across multiple model contexts
+
+**MCP SDK Version**: 0.14.0
 
 **Available Starters:**
 - `spring-ai-alibaba-starter-mcp-registry`

--- a/mcp/spring-ai-alibaba-mcp-common/pom.xml
+++ b/mcp/spring-ai-alibaba-mcp-common/pom.xml
@@ -53,7 +53,6 @@
     </scm>
 
     <properties>
-        <mcp-spring.version>0.14.0</mcp-spring.version>
         <json-schema-validator.version>1.5.3</json-schema-validator.version>
     </properties>
 
@@ -90,7 +89,6 @@
         <dependency>
             <groupId>io.modelcontextprotocol.sdk</groupId>
             <artifactId>mcp-spring-webflux</artifactId>
-            <version>${mcp-spring.version}</version>
         </dependency>
 
         <dependency>

--- a/mcp/spring-ai-alibaba-mcp-gateway/README.md
+++ b/mcp/spring-ai-alibaba-mcp-gateway/README.md
@@ -1,0 +1,190 @@
+# Spring AI Alibaba MCP Gateway
+
+基于 Spring AI 的 MCP (Model Context Protocol) Gateway 实现，提供统一的 MCP 服务网关功能，支持多种协议和认证方式。
+
+## 功能特性
+
+- **多协议支持**: 支持 HTTP/HTTPS、MCP-SSE、MCP-Streamable 协议
+- **Nacos 服务发现**: 与 Nacos 注册中心集成，自动发现 MCP 服务
+- **OAuth 认证**: 支持 OAuth 2.0 客户端凭证模式认证
+- **动态配置**: 支持 Nacos 配置中心动态更新
+- **工具回调**: 提供 Spring AI ToolCallback 实现
+
+## MCP SDK 版本兼容性
+
+### 支持版本
+
+| 组件 | 版本 |
+|------|------|
+| MCP Java SDK | 0.14.x |
+| 最低版本 | 0.14.0 |
+| Spring AI | 兼容 |
+
+### 版本升级说明
+
+从旧版本升级到 MCP SDK 0.14.0：
+
+#### 1. 更新父 POM 版本
+
+```xml
+<properties>
+    <mcp.version>0.14.0</mcp.version>
+</properties>
+```
+
+#### 2. 移除模块级版本覆盖
+
+如果模块 pom.xml 中存在本地版本覆盖，请移除：
+
+```xml
+<!-- 移除此类配置 -->
+<properties>
+    <mcp-spring.version>0.14.0</mcp-spring.version>
+</properties>
+```
+
+#### 3. 使用 BOM 管理版本
+
+确保父 POM 导入了 MCP BOM：
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp-bom</artifactId>
+            <version>${mcp.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+### API 兼容性
+
+MCP SDK 0.14.0 保持向后兼容，以下 API 无需修改：
+
+| API | 状态 |
+|-----|------|
+| `McpClient.sync(transport).build()` | ✅ 兼容 |
+| `HttpClientSseClientTransport.builder()` | ✅ 兼容 |
+| `WebClientStreamableHttpTransport.builder()` | ✅ 兼容 |
+| `CallToolResult.content()` | ✅ 兼容 |
+| `TextContent.text()` | ✅ 兼容 |
+| `McpSchema.CallToolRequest` | ✅ 兼容 |
+| `McpSchema.InitializeResult` | ✅ 兼容 |
+
+### 已知限制
+
+1. **连接池**: 当前版本未实现连接池，每次调用创建新连接
+2. **性能考虑**: 高频调用场景建议考虑连接复用策略
+
+## 快速开始
+
+### 1. 添加依赖
+
+```xml
+<dependency>
+    <groupId>com.alibaba.cloud.ai</groupId>
+    <artifactId>spring-ai-alibaba-mcp-gateway</artifactId>
+    <version>${revision}</version>
+</dependency>
+```
+
+### 2. 配置属性
+
+```yaml
+spring:
+  cloud:
+    nacos:
+      discovery:
+        server-addr: localhost:8848
+        username: nacos
+        password: nacos
+```
+
+## OAuth 配置
+
+MCP Gateway 支持通过 OAuth 2.0 为外部服务调用提供透明的身份验证。
+
+### 启用 OAuth 验证
+
+```yaml
+spring:
+  ai:
+    alibaba:
+      mcp:
+        gateway:
+          oauth:
+            enabled: true
+            provider:
+              client-id: your-client-id
+              client-secret: your-client-secret
+              token-uri: https://your-oauth-server.com/oauth/token
+              grant-type: client_credentials
+              scope: read,write
+            token-cache:
+              enabled: true
+              max-size: 1000
+              refresh-before-expiry: PT5M
+            retry:
+              max-attempts: 3
+              backoff: PT1S
+```
+
+### 配置参数说明
+
+| 参数 | 说明 |
+|------|------|
+| `enabled` | 是否启用 OAuth 认证 |
+| `provider.client-id` | OAuth 客户端 ID |
+| `provider.client-secret` | OAuth 客户端密钥 |
+| `provider.token-uri` | 获取访问令牌的端点 URL |
+| `provider.grant-type` | OAuth 授权类型（默认 `client_credentials`） |
+| `provider.scope` | 请求的权限范围 |
+| `token-cache.enabled` | 是否启用 Token 缓存 |
+| `token-cache.max-size` | 缓存最大大小 |
+| `token-cache.refresh-before-expiry` | Token 过期前刷新时间 |
+| `retry.max-attempts` | 最大重试次数 |
+| `retry.backoff` | 重试间隔 |
+
+### 支持的授权类型
+
+- `client_credentials`: 客户端凭证模式（推荐用于服务间通信）
+- `authorization_code`: 授权码模式
+- `password`: 密码模式
+- `refresh_token`: 刷新令牌模式
+
+## 核心组件
+
+### NacosMcpGatewayToolCallback
+
+实现 Spring AI `ToolCallback` 接口，提供：
+
+- 自动协议检测（HTTP/HTTPS、SSE、Streamable）
+- OAuth 透明认证
+- 请求模板渲染
+- 响应解析
+
+### 协议处理
+
+| 协议 | 传输实现 |
+|------|----------|
+| HTTP/HTTPS | WebClient |
+| MCP-SSE | HttpClientSseClientTransport |
+| MCP-Streamable | WebClientStreamableHttpTransport |
+
+## 模块依赖
+
+```
+spring-ai-alibaba-mcp-gateway
+├── spring-ai-alibaba-mcp-common
+├── nacos-client (Nacos3)
+├── spring-webflux
+└── reactor-netty-http
+```
+
+## 许可证
+
+Apache License 2.0

--- a/mcp/spring-ai-alibaba-mcp-gateway/README.md
+++ b/mcp/spring-ai-alibaba-mcp-gateway/README.md
@@ -149,12 +149,9 @@ spring:
 | `retry.max-attempts` | 最大重试次数 |
 | `retry.backoff` | 重试间隔 |
 
-### 支持的授权类型
+### 当前支持的授权类型
 
 - `client_credentials`: 客户端凭证模式（推荐用于服务间通信）
-- `authorization_code`: 授权码模式
-- `password`: 密码模式
-- `refresh_token`: 刷新令牌模式
 
 ## 核心组件
 

--- a/mcp/spring-ai-alibaba-mcp-router/pom.xml
+++ b/mcp/spring-ai-alibaba-mcp-router/pom.xml
@@ -52,7 +52,7 @@
     </scm>
 
     <properties>
-        <mcp.version>0.10.0</mcp.version>
+        <mcp.version>0.14.0</mcp.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
         <poi.version>5.4.0</poi.version>
         <tika.version>3.2.3</tika.version>
 
-        <mcp.version>0.11.2</mcp.version>
+        <mcp.version>0.14.0</mcp.version>
         <opentelemetry.version>1.38.0</opentelemetry.version>
         <a2a-sdk.version>0.2.5.Beta2</a2a-sdk.version>
 


### PR DESCRIPTION
## Summary
- Upgrade MCP Java SDK from 0.11.2/0.10.0 to 0.14.0 across all modules
- Consolidate version management to avoid dependency conflicts
- Add MCP Gateway README documentation with version compatibility info

## Changes

### Version Consolidation
| Module | Before | After |
|--------|--------|-------|
| Root BOM (`pom.xml`) | 0.11.2 | **0.14.0** |
| mcp-common | 0.14.0 (local override) | inherits from parent |
| mcp-router | 0.10.0 (local override) | **0.14.0** |

### Files Modified
1. `pom.xml`: Updated `mcp.version` from `0.11.2` to `0.14.0`
2. `mcp/spring-ai-alibaba-mcp-common/pom.xml`: Removed local `mcp-spring.version` override
3. `mcp/spring-ai-alibaba-mcp-router/pom.xml`: Updated `mcp.version` from `0.10.0` to `0.14.0`

### Documentation Added
1. `mcp/spring-ai-alibaba-mcp-gateway/README.md` (new): Complete documentation with version compatibility, upgrade instructions, and known limitations
2. `README.md` & `README-zh.md`: Updated MCP section with version info

## Verification
- ✅ Compilation: All 6 MCP modules compile successfully
- ✅ Unit Tests: 18 tests pass
- ✅ Dependency Tree: No version conflicts detected
- ✅ API Compatibility: No breaking changes found

## Key Findings
1. **No code changes required** - The existing code was already compatible with MCP SDK 0.14.0 APIs
2. **Version fragmentation resolved** - Previously 3 versions (0.10.0, 0.11.2, 0.14.0) coexisted; now unified to 0.14.0
3. **All APIs verified working**: `McpSyncClient`, `CallToolResult.content()`, `TextContent.text()`, transport builders

## Supported Version Range
- **MCP Java SDK**: 0.14.x
- **Minimum**: 0.14.0
- **Spring AI**: 1.1.2

## Known Limitations
- Connection pooling not implemented (performance consideration for future work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)