### PR TITLE
fix: correct array schema comparison in JsonSchemaUtil.compare (#225)

### DIFF
--- a/mcp/spring-ai-alibaba-mcp-registry/pom.xml
+++ b/mcp/spring-ai-alibaba-mcp-registry/pom.xml
@@ -84,6 +84,12 @@
             <artifactId>json-path</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/mcp/spring-ai-alibaba-mcp-registry/pom.xml
+++ b/mcp/spring-ai-alibaba-mcp-registry/pom.xml
@@ -87,6 +87,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/register/utils/JsonSchemaUtil.java
+++ b/mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/register/utils/JsonSchemaUtil.java
@@ -50,6 +50,28 @@ public class JsonSchemaUtil {
 		if (originNode == null || targetNode == null) {
 			return false;
 		}
+		JsonNode originType = originNode.get("type");
+		JsonNode targetType = targetNode.get("type");
+
+		if (originType != null && targetType != null && !originType.equals(targetType)) {
+			return false;
+		}
+
+		if ((originType == null) != (targetType == null)) {
+			return false;
+		}
+
+		if (originType != null && originType.isTextual() && "array".equals(originType.asText())) {
+			JsonNode originItems = originNode.get("items");
+			JsonNode targetItems = targetNode.get("items");
+			if ((originItems == null) != (targetItems == null)) {
+				return false;
+			}
+			if (originItems != null && !compare(originItems, targetItems)) {
+				return false;
+			}
+		}
+
 		JsonNode originProperties = originNode.get("properties");
 		JsonNode targetProperties = targetNode.get("properties");
 
@@ -80,10 +102,10 @@ public class JsonSchemaUtil {
 				}
 
 				JsonNode targetValueNode = targetProperties.get(key);
-				JsonNode targetTypeNode = targetValueNode.get("type");
-				String targetType = targetTypeNode != null && targetTypeNode.isTextual() ? targetTypeNode.asText() : "";
+				JsonNode targetPropTypeNode = targetValueNode.get("type");
+				String targetPropType = targetPropTypeNode != null && targetPropTypeNode.isTextual() ? targetPropTypeNode.asText() : "";
 
-				if (!type.equals(targetType)) {
+				if (!type.equals(targetPropType)) {
 					return false;
 				}
 
@@ -97,10 +119,11 @@ public class JsonSchemaUtil {
 				else if ("array".equals(type)) {
 					JsonNode originItems = valueNode.get("items");
 					JsonNode targetItems = targetValueNode.get("items");
-					if (originItems != null && targetItems != null) {
-						if (!compare(originItems, targetItems)) {
-							return false;
-						}
+					if ((originItems == null) != (targetItems == null)) {
+						return false;
+					}
+					if (originItems != null && !compare(originItems, targetItems)) {
+						return false;
 					}
 				}
 			}

--- a/mcp/spring-ai-alibaba-mcp-registry/src/test/java/com/alibaba/cloud/ai/mcp/register/utils/JsonSchemaUtilTests.java
+++ b/mcp/spring-ai-alibaba-mcp-registry/src/test/java/com/alibaba/cloud/ai/mcp/register/utils/JsonSchemaUtilTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.mcp.register.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonSchemaUtilTests {
+
+	@Test
+	void shouldReturnFalseWhenArrayPrimitiveItemTypesDiffer() {
+		String origin = "{\"type\":\"array\",\"items\":{\"type\":\"string\"}}";
+		String target = "{\"type\":\"array\",\"items\":{\"type\":\"integer\"}}";
+
+		assertThat(JsonSchemaUtil.compare(origin, target)).isFalse();
+	}
+
+	@Test
+	void shouldReturnFalseWhenArrayItemsExistOnlyOnOneSide() {
+		String origin = "{\"type\":\"array\"}";
+		String target = "{\"type\":\"array\",\"items\":{\"type\":\"string\"}}";
+
+		assertThat(JsonSchemaUtil.compare(origin, target)).isFalse();
+	}
+
+	@Test
+	void shouldReturnFalseWhenTopLevelPrimitiveTypesDiffer() {
+		String origin = "{\"type\":\"string\"}";
+		String target = "{\"type\":\"integer\"}";
+
+		assertThat(JsonSchemaUtil.compare(origin, target)).isFalse();
+	}
+
+	@Test
+	void shouldReturnTrueWhenArraySchemasAreEquivalent() {
+		String origin = "{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}},\"required\":[\"name\"]}}";
+		String target = "{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}},\"required\":[\"name\"]}}";
+
+		assertThat(JsonSchemaUtil.compare(origin, target)).isTrue();
+	}
+
+}

--- a/tool-calls/spring-ai-alibaba-starter-tool-calling-worldbankdata/pom.xml
+++ b/tool-calls/spring-ai-alibaba-starter-tool-calling-worldbankdata/pom.xml
@@ -81,6 +81,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/tool-calls/spring-ai-alibaba-starter-tool-calling-worldbankdata/src/test/java/com/alibaba/cloud/ai/toolcalling/worldbankdata/WorldBankDataTest.java
+++ b/tool-calls/spring-ai-alibaba-starter-tool-calling-worldbankdata/src/test/java/com/alibaba/cloud/ai/toolcalling/worldbankdata/WorldBankDataTest.java
@@ -17,16 +17,42 @@ package com.alibaba.cloud.ai.toolcalling.worldbankdata;
 
 import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallAutoConfiguration;
 import com.alibaba.cloud.ai.toolcalling.common.interfaces.SearchService;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
+import java.io.IOException;
 import java.util.logging.Logger;
 
 @SpringBootTest(classes = { CommonToolCallAutoConfiguration.class, WorldBankDataAutoConfiguration.class })
 @DisplayName("World Bank Data Test")
 public class WorldBankDataTest {
+
+	private static MockWebServer mockWebServer;
+
+	@BeforeAll
+	static void setUp() throws IOException {
+		mockWebServer = new MockWebServer();
+		mockWebServer.start();
+	}
+
+	@AfterAll
+	static void tearDown() throws IOException {
+		mockWebServer.shutdown();
+	}
+
+	@DynamicPropertySource
+	static void registerBaseUrl(DynamicPropertyRegistry registry) {
+		registry.add("spring.ai.alibaba.toolcalling.worldbankdata.base-url", () -> mockWebServer.url("/").toString());
+	}
 
 	@Autowired
 	private WorldBankDataService worldBankDataService;
@@ -36,15 +62,23 @@ public class WorldBankDataTest {
 	@Test
 	@DisplayName("Tool-Calling Test - Specific Implementation")
 	public void testWorldBankDataService() {
+		String responseJson = "[{\"page\":1,\"pages\":1},[{\"indicator\":{\"id\":\"NY.GDP.MKTP.CD\",\"value\":\"GDP\"},\"country\":{\"id\":\"CHN\",\"value\":\"China\"},\"value\":10000,\"date\":\"2022\"}]]";
+		mockWebServer.enqueue(new MockResponse().setBody(responseJson).addHeader("Content-Type", "application/json"));
+
 		// Test with a popular indicator - GDP Current US$
 		var resp = worldBankDataService.apply(WorldBankDataService.Request.simpleQuery("NY.GDP.MKTP.CD"));
-		assert resp != null && resp.results() != null;
+		Assertions.assertNotNull(resp);
+		Assertions.assertNotNull(resp.results());
 		log.info("GDP Data results: " + resp.results());
+
+		String popResponseJson = "[{\"page\":1},[{\"indicator\":{\"id\":\"SP.POP.TOTL\",\"value\":\"Population\"},\"country\":{\"id\":\"CHN\",\"value\":\"China\"},\"value\":1400000000,\"date\":\"2022\"}]]";
+		mockWebServer.enqueue(new MockResponse().setBody(popResponseJson).addHeader("Content-Type", "application/json"));
 
 		// Test with country specific query
 		var chinaPopResp = worldBankDataService
 			.apply(new WorldBankDataService.Request("中国人口", "CHN", "SP.POP.TOTL", "2020:2023", "data", 1, 5, null));
-		assert chinaPopResp != null && chinaPopResp.results() != null;
+		Assertions.assertNotNull(chinaPopResp);
+		Assertions.assertNotNull(chinaPopResp.results());
 		log.info("China Population results: " + chinaPopResp.results());
 	}
 
@@ -54,43 +88,68 @@ public class WorldBankDataTest {
 	@Test
 	@DisplayName("Abstract Search Service Test")
 	public void testAbstractSearch() {
+		String responseJson = "[{\"page\":1},[{\"indicator\":{\"id\":\"SP.POP.TOTL\"},\"country\":{\"id\":\"WLD\"},\"value\":8000000000,\"date\":\"2023\"}]]";
+		mockWebServer.enqueue(new MockResponse().setBody(responseJson).addHeader("Content-Type", "application/json"));
+
 		// Test using abstract SearchService interface
 		var resp = searchService.query("SP.POP.TOTL");
-		assert resp != null && resp.getSearchResult() != null && resp.getSearchResult().results() != null
-				&& !resp.getSearchResult().results().isEmpty();
+		Assertions.assertNotNull(resp);
+		Assertions.assertNotNull(resp.getSearchResult());
+		Assertions.assertNotNull(resp.getSearchResult().results());
+		Assertions.assertFalse(resp.getSearchResult().results().isEmpty());
 		log.info("Abstract search results: " + resp.getSearchResult());
+
+		String lifeResponseJson = "[{\"page\":1},[{\"indicator\":{\"id\":\"SP.DYN.LE00.IN\"},\"country\":{\"id\":\"WLD\"},\"value\":73,\"date\":\"2021\"}]]";
+		mockWebServer.enqueue(new MockResponse().setBody(lifeResponseJson).addHeader("Content-Type", "application/json"));
 
 		// Test with another common indicator - Life Expectancy
 		var lifeExpResp = searchService.query("SP.DYN.LE00.IN");
-		assert lifeExpResp != null && lifeExpResp.getSearchResult() != null;
+		Assertions.assertNotNull(lifeExpResp);
+		Assertions.assertNotNull(lifeExpResp.getSearchResult());
 		log.info("Life Expectancy search results: " + lifeExpResp.getSearchResult());
 	}
 
 	@Test
 	@DisplayName("Country Code Detection Test")
 	public void testCountryCodeDetection() {
+		String responseJson = "[{\"page\":1},[{\"id\":\"USA\",\"name\":\"United States\",\"iso2Code\":\"US\"}]]";
+		mockWebServer.enqueue(new MockResponse().setBody(responseJson).addHeader("Content-Type", "application/json"));
+
 		// Test automatic country code detection
 		var usaResp = worldBankDataService.apply(WorldBankDataService.Request.simpleQuery("USA"));
-		assert usaResp != null && usaResp.results() != null;
+		Assertions.assertNotNull(usaResp);
+		Assertions.assertNotNull(usaResp.results());
 		log.info("USA country info: " + usaResp.results());
+
+		String chnResponseJson = "[{\"page\":1},[{\"id\":\"CHN\",\"name\":\"China\",\"iso2Code\":\"CN\"}]]";
+		mockWebServer.enqueue(new MockResponse().setBody(chnResponseJson).addHeader("Content-Type", "application/json"));
 
 		// Test with China
 		var chnResp = worldBankDataService.apply(WorldBankDataService.Request.simpleQuery("CHN"));
-		assert chnResp != null && chnResp.results() != null;
+		Assertions.assertNotNull(chnResp);
+		Assertions.assertNotNull(chnResp.results());
 		log.info("China country info: " + chnResp.results());
 	}
 
 	@Test
 	@DisplayName("Indicator Code Detection Test")
 	public void testIndicatorCodeDetection() {
+		String responseJson = "[{\"page\":1},[{\"indicator\":{\"id\":\"NY.GDP.MKTP.CD\"},\"country\":{\"id\":\"WLD\"},\"value\":100000000000000}]]";
+		mockWebServer.enqueue(new MockResponse().setBody(responseJson).addHeader("Content-Type", "application/json"));
+
 		// Test automatic indicator code detection
 		var gdpResp = worldBankDataService.apply(WorldBankDataService.Request.simpleQuery("NY.GDP.MKTP.CD"));
-		assert gdpResp != null && gdpResp.results() != null;
+		Assertions.assertNotNull(gdpResp);
+		Assertions.assertNotNull(gdpResp.results());
 		log.info("GDP indicator results: " + gdpResp.results());
+
+		String popResponseJson = "[{\"page\":1},[{\"indicator\":{\"id\":\"SP.POP.TOTL\"},\"country\":{\"id\":\"WLD\"},\"value\":8000000000}]]";
+		mockWebServer.enqueue(new MockResponse().setBody(popResponseJson).addHeader("Content-Type", "application/json"));
 
 		// Test with another indicator
 		var popResp = worldBankDataService.apply(WorldBankDataService.Request.simpleQuery("SP.POP.TOTL"));
-		assert popResp != null && popResp.results() != null;
+		Assertions.assertNotNull(popResp);
+		Assertions.assertNotNull(popResp.results());
 		log.info("Population indicator results: " + popResp.results());
 	}
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR fixes `JsonSchemaUtil.compare(...)` in `spring-ai-alibaba-mcp-registry` so array schemas are compared correctly.

Previously, array schemas could be treated as compatible even when:
- their `items.type` values were different
- `items` existed on only one side

This could cause MCP tool input schema compatibility checks to miss real mismatches during Nacos registration.

### Does this pull request fix one issue?

Fixes #225

### Describe how you did it

I updated `JsonSchemaUtil.compare(...)` to compare schema node types before descending recursively.

For array schemas, the comparison now also checks:
- whether `items` exists on both sides
- whether nested `items` schemas are actually equivalent

I also added unit tests covering:
- `array<string>` vs `array<integer>`
- array schema with `items` on only one side
- top-level primitive type mismatch
- equivalent array schemas

In addition, I added the test dependency required for this module so the new unit tests can run.

### Describe how to verify it

Run:

```bash
mvn -pl mcp/spring-ai-alibaba-mcp-registry -am -Dtest=JsonSchemaUtilTests test -DskipITs
