### PR TITLE
fix: preserve DashScope-specific ChatOptions (enableSearch) when tools are registered

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
@@ -120,7 +120,7 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
      *   <li>false (default): Disable internet search.
      * </ul>
      */
-    private @JsonProperty("enable_search") Boolean enableSearch = false;
+    private @JsonProperty("enable_search") Boolean enableSearch;
 
     /**
      * Models can specify the format of the returned content. Valid values: {"type": "text"} or {"type": "json_object"}
@@ -193,7 +193,7 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
     /**
      * Whether to enable the thinking process of the model.
      */
-    private @JsonProperty("enable_thinking") Boolean enableThinking = false;
+    private @JsonProperty("enable_thinking") Boolean enableThinking;
 
     /**
      * The maximum length of the thinking process takes effect when enable_thinking is true,


### PR DESCRIPTION
## Summary

Fixes alibaba/spring-ai-alibaba#4542.

### Problem
When tools are registered via ReactAgent's `.tools()` method, Spring AI framework creates `ToolCallingChatOptions` to carry tool information, which replaces the original `DashScopeChatOptions` in the Prompt.

In `DashScopeChatModel.buildRequestPrompt()`, the method uses `ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class, DashScopeChatOptions.class)` to create a new `DashScopeChatOptions`. Since `ToolCallingChatOptions` does not contain DashScope-specific fields like `enableSearch`/`enableThinking`, the resulting `DashScopeChatOptions` gets the field-level default values (`false`).

Then during `ModelOptionsUtils.merge(runtimeOptions, defaultOptions, ...)`, because `runtimeOptions.enableSearch = false` (non-null), it overrides `defaultOptions.enableSearch = true` — the user's intended configuration is permanently lost.

### Root Cause
`enableSearch` and `enableThinking` in `DashScopeChatOptions` are initialized with non-null default values (`false`), which prevents `ModelOptionsUtils.merge()` from falling through to the `defaultOptions` values.

### Solution
Changed the default values of `enableSearch` and `enableThinking` from `false` to `null` (unset) in `DashScopeChatOptions`. This aligns with `multiModel` which already uses `null` as default. When these fields are `null` in `runtimeOptions`, `ModelOptionsUtils.merge()` correctly uses the values from `defaultOptions`.

### Changes
- `DashScopeChatOptions.java`: `enableSearch`: `false` → `null`
- `DashScopeChatOptions.java`: `enableThinking`: `false` → `null`

### Why not `incrementalOutput`?
`incrementalOutput` defaults to `true` and has the same theoretical issue, but changing it would alter the default streaming behavior. This is left for a separate discussion.

### Testing
- The fix is minimal (2 lines) and follows the same pattern as the existing `multiModel` field fix
- `null` for Boolean fields in DashScope API means "use server default" which is equivalent to `false` for both enableSearch and enableThinking