### PR TITLE
fix: add missing `spring-boot-configuration-processor` to annotationProcessorPaths for maven compile phrase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -499,12 +499,12 @@
                     <compilerArgs>
                         <compilerArg>-parameters</compilerArg>
                     </compilerArgs>
-                  <annotationProcessorPaths>
-                    <path>
-                      <groupId>org.springframework.boot</groupId>
-                      <artifactId>spring-boot-configuration-processor</artifactId>
-                    </path>
-                  </annotationProcessorPaths>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-configuration-processor</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
                 <executions>
                     <!-- Replacing default-compile as it is treated specially by Maven -->

--- a/pom.xml
+++ b/pom.xml
@@ -499,6 +499,12 @@
                     <compilerArgs>
                         <compilerArg>-parameters</compilerArg>
                     </compilerArgs>
+                  <annotationProcessorPaths>
+                    <path>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-configuration-processor</artifactId>
+                    </path>
+                  </annotationProcessorPaths>
                 </configuration>
                 <executions>
                     <!-- Replacing default-compile as it is treated specially by Maven -->


### PR DESCRIPTION
### Describe what this PR does / why we need it
fix: add missing `spring-boot-configuration-processor` to annotationProcessorPaths for maven compile phrase