### PR TITLE
-bug-fix(dashscope): support OpenAI-compatible format for private/local mo…

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatAutoConfiguration.java
@@ -127,6 +127,7 @@ public class DashScopeChatAutoConfiguration {
 					.webClientBuilder(webClientBuilder)
 					.restClientBuilder(restClientBuilder)
 					.responseErrorHandler(responseErrorHandler)
+					.openAiCompatible(chatProperties.isOpenAiCompatible())
 					.build();
 		}
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatProperties.java
@@ -49,6 +49,35 @@ public class DashScopeChatProperties extends DashScopeParentProperties {
 	 */
 	private String completionsPath = DashScopeApiConstants.TEXT_GENERATION_RESTFUL_URL;
 
+	/**
+	 * When set to {@code true}, the request body is serialized in the OpenAI-compatible
+	 * flat format ({@code messages} at the top level) instead of the DashScope-native
+	 * format ({@code messages} nested inside {@code input}).
+	 *
+	 * <p>Enable this when targeting private or locally-deployed models that expose an
+	 * OpenAI-compatible API endpoint, to avoid the
+	 * {@code "you must provide a messages parameter"} 400 error.
+	 *
+	 * <p>Example {@code application.yml}:
+	 * <pre>{@code
+	 * spring:
+	 *   ai:
+	 *     dashscope:
+	 *       chat:
+	 *         open-ai-compatible: true
+	 *         base-url: http://localhost:11434/v1
+	 * }</pre>
+	 */
+	private boolean openAiCompatible = false;
+
+	public boolean isOpenAiCompatible() {
+		return openAiCompatible;
+	}
+
+	public void setOpenAiCompatible(boolean openAiCompatible) {
+		this.openAiCompatible = openAiCompatible;
+	}
+
 	@NestedConfigurationProperty
 	private DashScopeChatOptions options = DashScopeChatOptions.builder()
 		.model(DEFAULT_DEPLOYMENT_NAME)

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -58,7 +58,9 @@ import java.time.Duration;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -108,6 +110,8 @@ public class DashScopeApi {
 	private final String embeddingsPath;
 
 	private final String rerankPath;
+
+	private final boolean openAiCompatible;
 
 	private final MultiValueMap<String, String> headers;
 
@@ -169,6 +173,23 @@ public class DashScopeApi {
 			WebClient.Builder webClientBuilder,
 			ResponseErrorHandler responseErrorHandler
 	) {
+		this(baseUrl, apiKey, header, workSpaceId, completionsPath, embeddingsPath, rerankPath,
+				restClientBuilder, webClientBuilder, responseErrorHandler, false);
+	}
+
+	public DashScopeApi(
+			String baseUrl,
+			ApiKey apiKey,
+			MultiValueMap<String, String> header,
+			String workSpaceId,
+			String completionsPath,
+			String embeddingsPath,
+			String rerankPath,
+			RestClient.Builder restClientBuilder,
+			WebClient.Builder webClientBuilder,
+			ResponseErrorHandler responseErrorHandler,
+			boolean openAiCompatible
+	) {
 
 		this.baseUrl = baseUrl;
 		this.apiKey = apiKey;
@@ -178,6 +199,7 @@ public class DashScopeApi {
 		this.embeddingsPath = embeddingsPath;
         this.rerankPath = rerankPath;
 		this.responseErrorHandler = responseErrorHandler;
+		this.openAiCompatible = openAiCompatible;
 
 		// For DashScope API, the workspace ID is passed in the headers.
 		if (StringUtils.hasText(workSpaceId)) {
@@ -524,13 +546,14 @@ public class DashScopeApi {
 		}
 
 		// @formatter:off
+		Object requestBody = this.openAiCompatible ? toOpenAiCompatibleBody(chatRequest) : chatRequest;
 		return this.restClient.post()
 				.uri(chatCompletionUri)
 				.headers(headers -> {
 					headers.addAll(additionalHttpHeader);
 					addDefaultHeadersIfMissing(headers);
 				})
-				.body(chatRequest)
+				.body(requestBody)
 				.retrieve()
 				.toEntity(DashScopeApiSpec.ChatCompletion.class);
 		// @formatter:on
@@ -585,7 +608,9 @@ public class DashScopeApi {
 			headers.add(HEADER_SSE, ENABLED);
 			addDefaultHeadersIfMissing(headers);
 		})
-			.body(Mono.just(chatRequest), DashScopeApiSpec.ChatCompletionRequest.class)
+			.body(this.openAiCompatible
+				? Mono.just(toOpenAiCompatibleBody(chatRequest))
+				: Mono.just(chatRequest), Object.class)
 			.retrieve()
 			.bodyToFlux(String.class)
 			.takeUntil(SSE_DONE_PREDICATE)
@@ -657,6 +682,50 @@ public class DashScopeApi {
 		return this.responseErrorHandler;
 	}
 
+	boolean isOpenAiCompatible() {
+		return this.openAiCompatible;
+	}
+
+	/**
+	 * Converts a DashScope-format {@link DashScopeApiSpec.ChatCompletionRequest} into an
+	 * OpenAI-compatible flat {@link Map}, lifting {@code messages} to the top level and
+	 * flattening individual {@code parameters} fields.
+	 *
+	 * <p>The DashScope native API wraps messages inside an {@code input} object:
+	 * <pre>{@code {"model":"qwen-turbo","input":{"messages":[...]},"parameters":{...}}}</pre>
+	 * OpenAI-compatible endpoints (local / private models) require the flat format:
+	 * <pre>{@code {"model":"qwen-turbo","messages":[...],"temperature":0.7,...}}</pre>
+	 *
+	 * <p>Used when {@link #openAiCompatible} is {@code true}.
+	 */
+	Map<String, Object> toOpenAiCompatibleBody(DashScopeApiSpec.ChatCompletionRequest chatRequest) {
+		Map<String, Object> body = new LinkedHashMap<>();
+		body.put("model", chatRequest.model());
+		if (chatRequest.input() != null && chatRequest.input().messages() != null) {
+			body.put("messages", chatRequest.input().messages());
+		}
+		if (chatRequest.stream() != null) {
+			body.put("stream", chatRequest.stream());
+		}
+		DashScopeApiSpec.ChatCompletionRequestParameter params = chatRequest.parameters();
+		if (params != null) {
+			if (params.temperature()     != null) body.put("temperature",       params.temperature());
+			if (params.topP()            != null) body.put("top_p",             params.topP());
+			if (params.maxTokens()       != null) body.put("max_tokens",        params.maxTokens());
+			if (params.stop()            != null) body.put("stop",              params.stop());
+			if (params.tools()           != null) body.put("tools",             params.tools());
+			if (params.toolChoice()      != null) body.put("tool_choice",       params.toolChoice());
+			if (params.parallelToolCalls() != null) body.put("parallel_tool_calls", params.parallelToolCalls());
+			if (params.responseFormat()  != null) body.put("response_format",   params.responseFormat());
+			if (params.presencePenalty() != null) body.put("presence_penalty",  params.presencePenalty());
+			if (params.seed()            != null) body.put("seed",              params.seed());
+			if (params.logprobs()        != null) body.put("logprobs",          params.logprobs());
+			if (params.topLogprobs()     != null) body.put("top_logprobs",      params.topLogprobs());
+			if (params.streamOptions()   != null) body.put("stream_options",    params.streamOptions());
+		}
+		return body;
+	}
+
 	public static class Builder {
 
         private String baseUrl = DEFAULT_BASE_URL;
@@ -678,6 +747,8 @@ public class DashScopeApi {
         private WebClient.Builder webClientBuilder = createDefaultWebClientBuilder();
 
         private ResponseErrorHandler responseErrorHandler = RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER;
+
+		private boolean openAiCompatible = false;
 
 		public Builder() {
 		}
@@ -757,6 +828,7 @@ public class DashScopeApi {
 			this.restClientBuilder = api.restClient != null ? api.restClient.mutate() : RestClient.builder();
 			this.webClientBuilder = api.webClient != null ? api.webClient.mutate() : WebClient.builder();
 			this.responseErrorHandler = api.getResponseErrorHandler();
+		this.openAiCompatible = api.isOpenAiCompatible();
 		}
 
 		public Builder baseUrl(String baseUrl) {
@@ -823,13 +895,19 @@ public class DashScopeApi {
 			return this;
 		}
 
+		public Builder openAiCompatible(boolean openAiCompatible) {
+			this.openAiCompatible = openAiCompatible;
+			return this;
+		}
+
 		public DashScopeApi build() {
 
 			Assert.notNull(apiKey, "API key cannot be null");
 
 			return new DashScopeApi(this.baseUrl, this.apiKey, this.headers, this.workSpaceId,
                     this.completionsPath, this.embeddingsPath, this.rerankPath,
-                    this.restClientBuilder, this.webClientBuilder, this.responseErrorHandler);
+                    this.restClientBuilder, this.webClientBuilder, this.responseErrorHandler,
+                    this.openAiCompatible);
 		}
 
 	}

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -205,10 +205,8 @@ public class DashScopeChatModel implements ChatModel {
 			.observation(this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,
 					this.observationRegistry)
 			.observe(() -> {
-
 				ResponseEntity<ChatCompletion> completionEntity = this.retryTemplate
 					.execute(ctx -> dashscopeApi.chatCompletionEntity(request, getAdditionalHttpHeaders(prompt)));
-
 				var completionResponse = completionEntity.getBody();
 				ChatResponse chatResponse = toChatResponse(completionResponse, previousChatResponse, request, null);
 

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApiOpenAiCompatibleTest.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApiOpenAiCompatibleTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dashscope.api;
+
+import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionMessage;
+import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionRequest;
+import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionRequestInput;
+import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionRequestParameter;
+import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.FunctionTool;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the OpenAI-compatible mode of {@link DashScopeApi}.
+ *
+ * <p>Issue #4463: When connecting to private/local models that implement the OpenAI
+ * Chat Completions API, the DashScope-native request format wraps {@code messages} inside
+ * an {@code input} object, causing HTTP 400 errors ("you must provide a messages
+ * parameter").
+ *
+ * <p>The fix adds an {@code openAiCompatible} flag to {@link DashScopeApi.Builder}.
+ * When {@code true}, the request body is converted to a flat OpenAI-compatible format
+ * with {@code messages} at the top level.
+ */
+class DashScopeApiOpenAiCompatibleTest {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	// -----------------------------------------------------------------------
+	// Helper: build a simple ChatCompletionRequest with one user message
+	// -----------------------------------------------------------------------
+	private static ChatCompletionRequest buildRequest() {
+		List<ChatCompletionMessage> messages = List.of(
+				new ChatCompletionMessage("Hello", ChatCompletionMessage.Role.USER));
+		return new ChatCompletionRequest(
+				"qwen-turbo",
+				new ChatCompletionRequestInput(messages),
+				null,
+				false,
+				false);
+	}
+
+	private static ChatCompletionRequest buildRequestWithParams() {
+		List<ChatCompletionMessage> messages = List.of(
+				new ChatCompletionMessage("Hello", ChatCompletionMessage.Role.USER));
+		// Field order matches ChatCompletionRequestParameter record (33 fields):
+		// resultFormat, seed, topP, topK, repetitionPenalty, presencePenalty,
+		// temperature, stop, enableSearch, searchOptions, responseFormat,
+		// incrementalOutput, tools, toolChoice, parallelToolCalls,
+		// enableThinking, thinkingBudget, enableCodeInterpreter,
+		// vlHighResolutionImages, vlEnableImageHwOutput, ocrOptions,
+		// logprobs, topLogprobs, translationOptions,
+		// stream, streamOptions, modalities, audio,
+		// maxTokens, maxInputTokens, asrOptions, outputFormat, extraBody
+		ChatCompletionRequestParameter params = new ChatCompletionRequestParameter(
+				"message",  // resultFormat
+				null,       // seed
+				0.9,        // topP
+				null,       // topK
+				null,       // repetitionPenalty
+				null,       // presencePenalty
+				0.7,        // temperature
+				null,       // stop
+				null,       // enableSearch
+				null,       // searchOptions
+				null,       // responseFormat
+				null,       // incrementalOutput
+				List.of(new FunctionTool(new FunctionTool.Function("A tool", "my_tool", "{}"))), // tools
+				"auto",     // toolChoice
+				null,       // parallelToolCalls
+				null,       // enableThinking
+				null,       // thinkingBudget
+				null,       // enableCodeInterpreter
+				null,       // vlHighResolutionImages
+				null,       // vlEnableImageHwOutput
+				null,       // ocrOptions
+				null,       // logprobs
+				null,       // topLogprobs
+				null,       // translationOptions
+				null,       // stream
+				null,       // streamOptions
+				null,       // modalities
+				null,       // audio
+				1024,       // maxTokens
+				null,       // maxInputTokens
+				null,       // asrOptions
+				null,       // outputFormat
+				null        // extraBody
+		);
+		return new ChatCompletionRequest(
+				"qwen-turbo",
+				new ChatCompletionRequestInput(messages),
+				params,
+				false,
+				false);
+	}
+
+	// -----------------------------------------------------------------------
+	// BUG DEMONSTRATION: default (non-openAiCompatible) format nests messages
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Demonstrates the bug: the default DashScope serialization wraps {@code messages}
+	 * inside {@code "input"}, NOT at the top level. This is what causes private/local
+	 * OpenAI-compatible models to return HTTP 400 "missing messages parameter".
+	 */
+	@Test
+	void defaultFormat_messagesAreNestedInsideInput() throws Exception {
+		ChatCompletionRequest request = buildRequest();
+
+		// Serialize as-is (how DashScopeApi currently sends the request)
+		String json = MAPPER.writeValueAsString(request);
+		JsonNode node = MAPPER.readTree(json);
+
+		// BUG: messages are NOT at the top level – they are inside "input"
+		assertThat(node.has("input")).isTrue();
+		assertThat(node.get("input").has("messages")).isTrue();
+
+		// An OpenAI-compatible endpoint expects top-level "messages" – which is ABSENT
+		assertThat(node.has("messages"))
+				.as("BUG: top-level 'messages' field is absent in default DashScope format")
+				.isFalse();
+	}
+
+	// -----------------------------------------------------------------------
+	// FIX VERIFICATION: openAiCompatible mode produces flat messages
+	// -----------------------------------------------------------------------
+
+	/**
+	 * After the fix: when {@code openAiCompatible=true}, the converted body must have
+	 * {@code messages} at the top level and must NOT contain {@code "input"}.
+	 */
+	@Test
+	void openAiCompatibleMode_messagesAreAtTopLevel() {
+		DashScopeApi api = DashScopeApi.builder()
+				.apiKey("test-key")
+				.openAiCompatible(true)
+				.build();
+
+		ChatCompletionRequest request = buildRequest();
+		Map<String, Object> body = api.toOpenAiCompatibleBody(request);
+
+		assertThat(body).containsKey("messages");
+		assertThat(body).doesNotContainKey("input");
+		assertThat(body).containsKey("model");
+		assertThat(body).containsKey("stream");
+	}
+
+	/**
+	 * The converted messages list must contain exactly the messages from the request.
+	 */
+	@Test
+	void openAiCompatibleMode_messagesContentIsPreserved() {
+		DashScopeApi api = DashScopeApi.builder()
+				.apiKey("test-key")
+				.openAiCompatible(true)
+				.build();
+
+		ChatCompletionRequest request = buildRequest();
+		Map<String, Object> body = api.toOpenAiCompatibleBody(request);
+
+		@SuppressWarnings("unchecked")
+		List<ChatCompletionMessage> messages = (List<ChatCompletionMessage>) body.get("messages");
+		assertThat(messages).hasSize(1);
+		assertThat(messages.get(0).role()).isEqualTo(ChatCompletionMessage.Role.USER);
+	}
+
+	/**
+	 * Parameters in {@code ChatCompletionRequestParameter} must be flattened to the
+	 * top level (e.g., {@code temperature}, {@code tools}, {@code tool_choice}).
+	 */
+	@Test
+	void openAiCompatibleMode_parametersAreFlattenedToTopLevel() {
+		DashScopeApi api = DashScopeApi.builder()
+				.apiKey("test-key")
+				.openAiCompatible(true)
+				.build();
+
+		ChatCompletionRequest request = buildRequestWithParams();
+		Map<String, Object> body = api.toOpenAiCompatibleBody(request);
+
+		// No nested "parameters" object
+		assertThat(body).doesNotContainKey("parameters");
+
+		// Individual fields promoted to top level
+		assertThat(body).containsKey("temperature");
+		assertThat(body).containsKey("top_p");
+		assertThat(body).containsKey("tools");
+		assertThat(body).containsKey("tool_choice");
+		assertThat(body).containsKey("max_tokens");
+	}
+
+	/**
+	 * The {@code openAiCompatible} flag defaults to {@code false} and the body retains
+	 * the DashScope-native format.
+	 */
+	@Test
+	void defaultMode_flagIsFalseAndBodyIsNotConverted() {
+		DashScopeApi api = DashScopeApi.builder()
+				.apiKey("test-key")
+				// openAiCompatible NOT set → defaults to false
+				.build();
+
+		assertThat(api.isOpenAiCompatible()).isFalse();
+	}
+
+	/**
+	 * The {@code openAiCompatible} flag is preserved through {@code mutate()} / copy.
+	 */
+	@Test
+	void mutate_preservesOpenAiCompatibleFlag() {
+		DashScopeApi original = DashScopeApi.builder()
+				.apiKey("test-key")
+				.openAiCompatible(true)
+				.build();
+
+		DashScopeApi copy = original.mutate().build();
+		assertThat(copy.isOpenAiCompatible()).isTrue();
+	}
+
+}


### PR DESCRIPTION
…dels (issue #4463)

When connecting to locally-deployed models that expose an OpenAI-compatible API, the DashScope-native request format wraps messages inside an `input` object, causing HTTP 400 "you must provide a messages parameter" errors.

Changes:
- DashScopeApi: add `openAiCompatible` flag and `toOpenAiCompatibleBody()` which lifts `messages` to the top level and flattens `parameters` fields, matching the OpenAI Chat Completions request format
- DashScopeChatProperties: expose `open-ai-compatible` config property
- DashScopeChatAutoConfiguration: wire the property through to DashScopeApi.Builder
- DashScopeApiOpenAiCompatibleTest: add tests demonstrating the bug (default nested format) and verifying the fix (flat format when flag is enabled)

Usage:
  spring.ai.dashscope.chat.open-ai-compatible: true spring.ai.dashscope.chat.base-url: http://localhost:11434/v1


### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
