### PR TITLE
feat:DashScopeException新增异常code

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -593,7 +593,7 @@ public class DashScopeApi {
 			.map(content -> {
 				DashScopeApiSpec.DashScopeErrorResponse error = ModelOptionsUtils.jsonToObject(content, DashScopeApiSpec.DashScopeErrorResponse.class);
 				if (error != null && error.code() != null) {
-					throw new DashScopeException(String.format("[%s] %s (requestId: %s)",
+					throw new DashScopeException(error.code(),String.format("[%s] %s (requestId: %s)",
 						error.code(), error.message(), error.requestId()));
 				}
 				DashScopeApiSpec.ChatCompletionChunk chunk = ModelOptionsUtils.jsonToObject(content, DashScopeApiSpec.ChatCompletionChunk.class);

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/common/DashScopeException.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/common/DashScopeException.java
@@ -21,16 +21,30 @@ package com.alibaba.cloud.ai.dashscope.common;
  */
 public class DashScopeException extends RuntimeException {
 
-	public DashScopeException(String message) {
-		super(message);
-	}
+    private final String code;
 
-	public DashScopeException(String message, Throwable cause) {
-		super(message, cause);
-	}
+    public DashScopeException(String message) {
+        super(message);
+        this.code = "DashScopeError";
+    }
 
-	public DashScopeException(ErrorCodeEnum error) {
-		super(error.getCode() + ":" + error.message());
-	}
+    public DashScopeException(String code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public DashScopeException(String message, Throwable cause) {
+        super(message, cause);
+        this.code = "DashScopeError";
+    }
+
+    public DashScopeException(ErrorCodeEnum error) {
+        super(error.getCode() + ":" + error.message());
+        this.code = error.getCode();
+    }
+
+    public String getCode() {
+        return this.code;
+    }
 
 }

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
@@ -657,6 +657,27 @@ class DashScopeChatModelTests {
     }
 
     @Test
+    void testStreamErrorResponseWithCode() {
+        Message message = new UserMessage("Test error handling");
+        Prompt prompt = new Prompt(List.of(message));
+
+        when(dashScopeApi.chatCompletionStream(any(), any())).thenReturn(Flux.error(
+                new com.alibaba.cloud.ai.dashscope.common.DashScopeException("InvalidParameter",
+                        "[InvalidParameter] invalid input (requestId: error-request-123)")));
+
+        Flux<ChatResponse> responseFlux = chatModel.stream(prompt);
+
+        StepVerifier.create(responseFlux)
+                .expectErrorMatches(throwable ->
+                        throwable instanceof com.alibaba.cloud.ai.dashscope.common.DashScopeException
+                                && ((com.alibaba.cloud.ai.dashscope.common.DashScopeException) throwable).getCode()
+                                .equals("InvalidParameter")
+                                && throwable.getMessage().contains("InvalidParameter")
+                                && throwable.getMessage().contains("error-request-123"))
+                .verify();
+    }
+
+    @Test
     void testBuildRequestPrompt() {
         DashScopeChatOptions runtimeOptions = DashScopeChatOptions.builder()
                 .model("qwen-plus")


### PR DESCRIPTION
### Describe what this PR does / why we need it
针对百炼模型返回异常时拿到对应的异常code

### Does this pull request fix one issue?
Fixes #4546

### Describe how you did it

在DashScopeException新增了异常code字段，并在流式调用百炼模型时候出现异常的情况下，把返回的code设置到DashScopeException中

### Describe how to verify it
mvn -pl models/dashscope -am test -DskipITs -Dspotless.skip=true -Dcheckstyle.skip=true -Dsort.skip=true

### Special notes for reviews
