### PR TITLE
feat(model): support sparse embeddings in DashScopeEmbeddingModel

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/embedding/text/DashScopeEmbeddingModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/embedding/text/DashScopeEmbeddingModel.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.dashscope.embedding.text;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,6 +63,13 @@ import org.springframework.util.Assert;
 public class DashScopeEmbeddingModel extends AbstractEmbeddingModel {
 
 	private static final Logger logger = LoggerFactory.getLogger(DashScopeEmbeddingModel.class);
+
+	/**
+	 * Metadata key for sparse embeddings stored in {@link EmbeddingResponseMetadata}. The
+	 * associated value is a {@code Map<Integer,
+	 * List<DashScopeApiSpec.SparseEmbeddingItem>>} keyed by DashScope {@code text_index}.
+	 */
+	public static final String SPARSE_EMBEDDINGS_METADATA = "sparse-embeddings";
 
 	private static final EmbeddingModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultEmbeddingModelObservationConvention();
 
@@ -174,14 +182,21 @@ public class DashScopeEmbeddingModel extends AbstractEmbeddingModel {
 
                     Usage embeddingUsage = usage != null ? this.getDefaultUsage(usage) : new EmptyUsage();
 
-                    var metadata = generateResponseMetadata(apiRequest.model(), embeddingUsage);
-                    List<Embedding> embeddings = apiEmbeddingResponse.output()
-                            .embeddings()
-                            .stream()
-                            .map(e -> new Embedding(e.embedding(), e.textIndex()))
-                            .toList();
+					Map<Integer, List<DashScopeApiSpec.SparseEmbeddingItem>> sparseEmbeddings = new HashMap<>();
+					List<Embedding> embeddings = new ArrayList<>();
+					if (apiEmbeddingResponse.output() != null && apiEmbeddingResponse.output().embeddings() != null) {
+						for (DashScopeApiSpec.Embedding embedding : apiEmbeddingResponse.output().embeddings()) {
+							int textIndex = embedding.textIndex() != null ? embedding.textIndex() : embeddings.size();
+							float[] denseEmbedding = embedding.embedding() != null ? embedding.embedding() : new float[0];
+							embeddings.add(new Embedding(denseEmbedding, textIndex));
+							if (embedding.sparseEmbedding() != null && !embedding.sparseEmbedding().isEmpty()) {
+								sparseEmbeddings.put(textIndex, embedding.sparseEmbedding());
+							}
+						}
+					}
+					var metadata = generateResponseMetadata(apiRequest.model(), embeddingUsage, sparseEmbeddings);
 
-                    EmbeddingResponse embeddingResponse = new EmbeddingResponse(embeddings, metadata);
+					EmbeddingResponse embeddingResponse = new EmbeddingResponse(embeddings, metadata);
 
                     observationContext.setResponse(embeddingResponse);
 
@@ -194,26 +209,27 @@ public class DashScopeEmbeddingModel extends AbstractEmbeddingModel {
 	}
 
 	private EmbeddingRequest buildEmbeddingRequest(EmbeddingRequest embeddingRequest) {
-		// Process runtime options
+		DashScopeEmbeddingOptions requestOptions = mergeOptions(embeddingRequest.getOptions());
+		return new EmbeddingRequest(embeddingRequest.getInstructions(), requestOptions);
+	}
+
+	private DashScopeEmbeddingOptions mergeOptions(EmbeddingOptions options) {
 		DashScopeEmbeddingOptions runtimeOptions = null;
-		if (embeddingRequest.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
+		if (options != null) {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(options, EmbeddingOptions.class,
 					DashScopeEmbeddingOptions.class);
 		}
 
-		DashScopeEmbeddingOptions requestOptions = runtimeOptions == null ? this.defaultOptions
+		return runtimeOptions == null ? this.defaultOptions
 				: DashScopeEmbeddingOptions.builder()
-					// Handle portable embedding options
 					.model(ModelOptionsUtils.mergeOption(runtimeOptions.getModel(), this.defaultOptions.getModel()))
 					.dimensions(ModelOptionsUtils.mergeOption(runtimeOptions.getDimensions(),
-							defaultOptions.getDimensions()))
-
-					// Handle dashscope specific embedding options
-					.textType(
-							ModelOptionsUtils.mergeOption(runtimeOptions.getTextType(), defaultOptions.getTextType()))
+							this.defaultOptions.getDimensions()))
+					.textType(ModelOptionsUtils.mergeOption(runtimeOptions.getTextType(),
+							this.defaultOptions.getTextType()))
+					.outputType(ModelOptionsUtils.mergeOption(runtimeOptions.getOutputType(),
+							this.defaultOptions.getOutputType()))
 					.build();
-
-		return new EmbeddingRequest(embeddingRequest.getInstructions(), requestOptions);
 	}
 
 	private DashScopeApiSpec.EmbeddingRequest createRequest(EmbeddingRequest request) {
@@ -223,13 +239,30 @@ public class DashScopeEmbeddingModel extends AbstractEmbeddingModel {
 			.texts(request.getInstructions())
 			.textType(requestOptions.getTextType())
 			.dimension(requestOptions.getDimensions())
+			.outputType(requestOptions.getOutputType())
 			.build();
 	}
 
-	private EmbeddingResponseMetadata generateResponseMetadata(String model, Usage usage) {
+	/**
+	 * Dense embedding convenience APIs cannot return sparse-only outputs because their
+	 * contract is fixed to {@code float[]} results. Callers that need sparse embeddings
+	 * must use {@link #call(EmbeddingRequest)} instead.
+	 */
+	private void validateDenseEmbeddingApiOutputType(DashScopeEmbeddingOptions options) {
+		if (DashScopeEmbeddingOptions.OUTPUT_TYPE_SPARSE.equalsIgnoreCase(options.getOutputType())) {
+			throw new IllegalStateException(
+					"DashScope sparse-only output cannot be returned from dense embedding APIs. Use call() to access sparse embeddings.");
+		}
+	}
+
+	private EmbeddingResponseMetadata generateResponseMetadata(String model, Usage usage,
+			Map<Integer, List<DashScopeApiSpec.SparseEmbeddingItem>> sparseEmbeddings) {
 		Map<String, Object> map = new HashMap<>();
 		map.put("model", model);
 		map.put("total-tokens", usage.getTotalTokens());
+		if (!sparseEmbeddings.isEmpty()) {
+			map.put(SPARSE_EMBEDDINGS_METADATA, sparseEmbeddings);
+		}
 
 		return new EmbeddingResponseMetadata(model, usage, map);
 	}
@@ -250,6 +283,7 @@ public class DashScopeEmbeddingModel extends AbstractEmbeddingModel {
 	@Override
 	public List<float[]> embed(List<String> texts) {
 		Assert.notNull(texts, "Texts must not be null");
+		validateDenseEmbeddingApiOutputType(this.defaultOptions);
 		return this.call(new EmbeddingRequest(texts, defaultOptions))
 			.getResults()
 			.stream()
@@ -263,10 +297,9 @@ public class DashScopeEmbeddingModel extends AbstractEmbeddingModel {
 	 */
 	@Override
 	public List<float[]> embed(List<Document> documents, EmbeddingOptions options, BatchingStrategy batchingStrategy) {
-		if (options.getModel() == null && options.getDimensions() == null && defaultOptions != null) {
-			options = defaultOptions;
-		}
-		return super.embed(documents, options, batchingStrategy);
+		DashScopeEmbeddingOptions requestOptions = mergeOptions(options);
+		validateDenseEmbeddingApiOutputType(requestOptions);
+		return super.embed(documents, requestOptions, batchingStrategy);
 	}
 
 	/**

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/embedding/text/DashScopeEmbeddingOptions.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/embedding/text/DashScopeEmbeddingOptions.java
@@ -30,9 +30,17 @@ import org.springframework.ai.embedding.EmbeddingOptions;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DashScopeEmbeddingOptions implements EmbeddingOptions {
 
+	public static final String OUTPUT_TYPE_DENSE = "dense";
+
+	public static final String OUTPUT_TYPE_SPARSE = "sparse";
+
+	public static final String OUTPUT_TYPE_DENSE_AND_SPARSE = "dense&sparse";
+
 	private @JsonProperty("model") String model;
 
 	private @JsonProperty("text_type") String textType;
+
+	private @JsonProperty("output_type") String outputType;
 
 	private @JsonProperty("dimensions") Integer dimensions;
 
@@ -67,6 +75,19 @@ public class DashScopeEmbeddingOptions implements EmbeddingOptions {
 
 	public void setTextType(String textType) {
 		this.textType = textType;
+	}
+
+	public String getOutputType() {
+		return this.outputType;
+	}
+
+	public void setOutputType(String outputType) {
+		if (outputType != null && !OUTPUT_TYPE_DENSE.equals(outputType) && !OUTPUT_TYPE_SPARSE.equals(outputType)
+				&& !OUTPUT_TYPE_DENSE_AND_SPARSE.equals(outputType)) {
+			throw new IllegalArgumentException(
+					"outputType only supports " + OUTPUT_TYPE_DENSE + ", " + OUTPUT_TYPE_SPARSE + ", " + OUTPUT_TYPE_DENSE_AND_SPARSE);
+		}
+		this.outputType = outputType;
 	}
 
 	public String getEmbeddingsPath() {
@@ -110,10 +131,16 @@ public class DashScopeEmbeddingOptions implements EmbeddingOptions {
 			return this;
 		}
 
+		public Builder outputType(String outputType) {
+			this.options.setOutputType(outputType);
+			return this;
+		}
+
 		@Deprecated
 		public Builder withTextType(String textType) {
 			return textType(textType);
 		}
+
 
 		public Builder embeddingsPath(String embeddingsPath) {
 			this.options.setEmbeddingsPath(embeddingsPath);

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
@@ -98,7 +98,18 @@ public class DashScopeApiSpec {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record Embedding(@JsonProperty("text_index") Integer textIndex,
-                            @JsonProperty("embedding") float[] embedding) {
+                            @JsonProperty("embedding") float[] embedding,
+                            @JsonProperty("sparse_embedding") List<SparseEmbeddingItem> sparseEmbedding) {
+
+        public Embedding(Integer textIndex, float[] embedding) {
+            this(textIndex, embedding, null);
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record SparseEmbeddingItem(@JsonProperty("index") Integer index,
+                                      @JsonProperty("token") String token,
+                                      @JsonProperty("value") Float value) {
     }
 
     // @formatter:off
@@ -123,11 +134,12 @@ public class DashScopeApiSpec {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record EmbeddingRequestInputParameters(@JsonProperty("text_type") String textType,
-                                                  @JsonProperty("dimension") Integer dimension) {
+                                                  @JsonProperty("dimension") Integer dimension,
+                                                  @JsonProperty("output_type") String outputType) {
 
         @Deprecated
         public EmbeddingRequestInputParameters(String textType) {
-            this(textType == null ? DEFAULT_EMBEDDING_TEXT_TYPE : textType, null);
+            this(textType == null ? DEFAULT_EMBEDDING_TEXT_TYPE : textType, null, null);
         }
 
         public static Builder builder() {
@@ -139,6 +151,8 @@ public class DashScopeApiSpec {
             private String textType;
 
             private Integer dimension;
+
+            private String outputType;
 
             private Builder() {
 
@@ -154,10 +168,15 @@ public class DashScopeApiSpec {
                 return this;
             }
 
+            public Builder outputType(String outputType) {
+                this.outputType = outputType;
+                return this;
+            }
+
             public EmbeddingRequestInputParameters build() {
                 // Handle null textType for FastJson compatibility.
                 String finalTextType = textType == null ? DEFAULT_EMBEDDING_TEXT_TYPE : textType;
-                return new EmbeddingRequestInputParameters(finalTextType, dimension);
+                return new EmbeddingRequestInputParameters(finalTextType, dimension, outputType);
             }
 
         }
@@ -221,6 +240,8 @@ public class DashScopeApiSpec {
 
             private Integer dimension;
 
+            private String outputType;
+
             private Builder() {
             }
 
@@ -249,9 +270,18 @@ public class DashScopeApiSpec {
                 return this;
             }
 
+            public Builder outputType(String outputType) {
+                this.outputType = outputType;
+                return this;
+            }
+
             public EmbeddingRequest build() {
                 return new EmbeddingRequest(model, new EmbeddingRequestInput(texts),
-                        EmbeddingRequestInputParameters.builder().textType(textType).dimension(dimension).build());
+                        EmbeddingRequestInputParameters.builder()
+                            .textType(textType)
+                            .dimension(dimension)
+                            .outputType(outputType)
+                            .build());
             }
 
         }
@@ -1584,4 +1614,3 @@ public class DashScopeApiSpec {
 	}
 
 }
-

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/embedding/text/DashScopeEmbeddingModelTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/embedding/text/DashScopeEmbeddingModelTests.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
+import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec;
 import com.alibaba.cloud.ai.dashscope.embedding.text.DashScopeEmbeddingModel.Builder;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.Embedding;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.EmbeddingList;
@@ -29,9 +30,11 @@ import com.alibaba.cloud.ai.dashscope.spec.DashScopeModel.EmbeddingModel;
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.MetadataMode;
+import org.springframework.ai.embedding.TokenCountBatchingStrategy;
 import org.springframework.ai.embedding.EmbeddingRequest;
 import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.retry.RetryUtils;
@@ -323,5 +326,144 @@ class DashScopeEmbeddingModelTests {
 
         assertThat(response.getMetadata().getUsage().getTotalTokens()).isEqualTo(10L);
     }
+
+	@Test
+	void testOutputTypePropagation() {
+		float[] embeddingVector = { 0.1f, 0.2f, 0.3f };
+		Embedding embedding = new Embedding(0, embeddingVector);
+		Embeddings embeddings = new Embeddings(List.of(embedding));
+		EmbeddingList embeddingList = new EmbeddingList(TEST_REQUEST_ID, null, null, embeddings, new EmbeddingUsage(10L));
+		when(dashScopeApi.embeddings(any())).thenReturn(ResponseEntity.ok(embeddingList));
+
+		DashScopeEmbeddingOptions options = DashScopeEmbeddingOptions.builder()
+			.model(TEST_MODEL)
+			.textType(TEST_TEXT_TYPE)
+			.dimensions(TEST_DIMENSION)
+			.outputType(DashScopeEmbeddingOptions.OUTPUT_TYPE_DENSE_AND_SPARSE)
+			.build();
+
+		embeddingModel.call(new EmbeddingRequest(List.of(TEST_TEXT), options));
+
+		ArgumentCaptor<DashScopeApiSpec.EmbeddingRequest> captor = ArgumentCaptor.forClass(DashScopeApiSpec.EmbeddingRequest.class);
+		verify(dashScopeApi).embeddings(captor.capture());
+		assertThat(captor.getValue().parameters().outputType())
+			.isEqualTo(DashScopeEmbeddingOptions.OUTPUT_TYPE_DENSE_AND_SPARSE);
+	}
+
+	@Test
+	void testSparseEmbeddingStoredInMetadata() {
+		DashScopeApiSpec.SparseEmbeddingItem sparseItem = new DashScopeApiSpec.SparseEmbeddingItem(108386, "你好", 2.3828f);
+		Embedding embedding = new Embedding(0, null, List.of(sparseItem));
+		Embeddings embeddings = new Embeddings(List.of(embedding));
+		EmbeddingList embeddingList = new EmbeddingList(TEST_REQUEST_ID, null, null, embeddings, new EmbeddingUsage(2L));
+		when(dashScopeApi.embeddings(any())).thenReturn(ResponseEntity.ok(embeddingList));
+
+		DashScopeEmbeddingOptions options = DashScopeEmbeddingOptions.builder()
+			.model(TEST_MODEL)
+			.textType(TEST_TEXT_TYPE)
+			.outputType(DashScopeEmbeddingOptions.OUTPUT_TYPE_SPARSE)
+			.build();
+
+		EmbeddingResponse response = embeddingModel.call(new EmbeddingRequest(List.of("你好"), options));
+
+		assertThat(response.getResults()).hasSize(1);
+		assertThat(response.getResults().get(0).getOutput()).isEmpty();
+		@SuppressWarnings("unchecked")
+		Map<Integer, List<DashScopeApiSpec.SparseEmbeddingItem>> sparseEmbeddings =
+				(Map<Integer, List<DashScopeApiSpec.SparseEmbeddingItem>>) response.getMetadata()
+					.get(DashScopeEmbeddingModel.SPARSE_EMBEDDINGS_METADATA);
+		assertThat(sparseEmbeddings).containsKey(0);
+		assertThat(sparseEmbeddings.get(0)).hasSize(1);
+		assertThat(sparseEmbeddings.get(0).get(0).index()).isEqualTo(108386);
+		assertThat(sparseEmbeddings.get(0).get(0).token()).isEqualTo("你好");
+		assertThat(sparseEmbeddings.get(0).get(0).value()).isEqualTo(2.3828f);
+	}
+
+	@Test
+	void testDenseAndSparseEmbeddingsAreBothReturned() {
+		float[] vector1 = { 0.1f, 0.2f, 0.3f };
+		float[] vector2 = { 0.4f, 0.5f, 0.6f };
+		DashScopeApiSpec.SparseEmbeddingItem sparse1 = new DashScopeApiSpec.SparseEmbeddingItem(7149, "风", 0.829f);
+		DashScopeApiSpec.SparseEmbeddingItem sparse2 = new DashScopeApiSpec.SparseEmbeddingItem(246351, "渚", 1.0483f);
+		List<Embedding> apiEmbeddings = List.of(
+				new Embedding(0, vector1, List.of(sparse1)),
+				new Embedding(1, vector2, List.of(sparse2)));
+		EmbeddingList embeddingList = new EmbeddingList(TEST_REQUEST_ID, null, null, new Embeddings(apiEmbeddings),
+				new EmbeddingUsage(27L));
+		when(dashScopeApi.embeddings(any())).thenReturn(ResponseEntity.ok(embeddingList));
+
+		DashScopeEmbeddingOptions options = DashScopeEmbeddingOptions.builder()
+			.model(TEST_MODEL)
+			.textType(TEST_TEXT_TYPE)
+			.outputType(DashScopeEmbeddingOptions.OUTPUT_TYPE_DENSE_AND_SPARSE)
+			.build();
+
+		EmbeddingResponse response = embeddingModel.call(new EmbeddingRequest(List.of("第一句", "第二句"), options));
+
+		assertThat(response.getResults()).hasSize(2);
+		assertThat(response.getResults().get(0).getOutput()).containsExactly(vector1);
+		assertThat(response.getResults().get(1).getOutput()).containsExactly(vector2);
+		assertThat(response.getResults().get(0).getIndex()).isEqualTo(0);
+		assertThat(response.getResults().get(1).getIndex()).isEqualTo(1);
+		@SuppressWarnings("unchecked")
+		Map<Integer, List<DashScopeApiSpec.SparseEmbeddingItem>> sparseEmbeddings =
+				(Map<Integer, List<DashScopeApiSpec.SparseEmbeddingItem>>) response.getMetadata()
+					.get(DashScopeEmbeddingModel.SPARSE_EMBEDDINGS_METADATA);
+		assertThat(sparseEmbeddings).hasSize(2);
+		assertThat(sparseEmbeddings.get(0).get(0).token()).isEqualTo("风");
+		assertThat(sparseEmbeddings.get(1).get(0).token()).isEqualTo("渚");
+	}
+
+	@Test
+	void testDocumentEmbeddingPathShouldPreserveOutputType() {
+		float[] embeddingVector = { 0.1f, 0.2f, 0.3f };
+		Embedding embedding = new Embedding(0, embeddingVector,
+				List.of(new DashScopeApiSpec.SparseEmbeddingItem(108386, "你好", 2.3828f)));
+		Embeddings embeddings = new Embeddings(List.of(embedding));
+		EmbeddingList embeddingList = new EmbeddingList(TEST_REQUEST_ID, null, null, embeddings, new EmbeddingUsage(10L));
+		when(dashScopeApi.embeddings(any())).thenReturn(ResponseEntity.ok(embeddingList));
+
+		DashScopeEmbeddingOptions options = DashScopeEmbeddingOptions.builder()
+			.outputType(DashScopeEmbeddingOptions.OUTPUT_TYPE_DENSE_AND_SPARSE)
+			.build();
+
+		embeddingModel.embed(List.of(new Document("你好")), options, new TokenCountBatchingStrategy());
+
+		ArgumentCaptor<DashScopeApiSpec.EmbeddingRequest> captor = ArgumentCaptor.forClass(DashScopeApiSpec.EmbeddingRequest.class);
+		verify(dashScopeApi).embeddings(captor.capture());
+		assertThat(captor.getValue().parameters().outputType())
+			.isEqualTo(DashScopeEmbeddingOptions.OUTPUT_TYPE_DENSE_AND_SPARSE);
+	}
+
+	@Test
+	void testDocumentEmbeddingPathShouldRejectSparseOnlyOutput() {
+		Embedding embedding = new Embedding(0, null,
+				List.of(new DashScopeApiSpec.SparseEmbeddingItem(108386, "你好", 2.3828f)));
+		Embeddings embeddings = new Embeddings(List.of(embedding));
+		EmbeddingList embeddingList = new EmbeddingList(TEST_REQUEST_ID, null, null, embeddings, new EmbeddingUsage(2L));
+		when(dashScopeApi.embeddings(any())).thenReturn(ResponseEntity.ok(embeddingList));
+
+		DashScopeEmbeddingOptions options = DashScopeEmbeddingOptions.builder()
+			.outputType(DashScopeEmbeddingOptions.OUTPUT_TYPE_SPARSE)
+			.build();
+
+		assertThatThrownBy(() -> embeddingModel.embed(List.of(new Document("你好")), options, new TokenCountBatchingStrategy()))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("sparse-only");
+	}
+
+	@Test
+	void testTextEmbeddingPathShouldRejectSparseOnlyDefaultOutput() {
+		DashScopeEmbeddingModel sparseDefaultModel = new DashScopeEmbeddingModel(dashScopeApi, MetadataMode.EMBED,
+				DashScopeEmbeddingOptions.builder()
+					.model(TEST_MODEL)
+					.textType(TEST_TEXT_TYPE)
+					.outputType(DashScopeEmbeddingOptions.OUTPUT_TYPE_SPARSE)
+					.build());
+
+		assertThatThrownBy(() -> sparseDefaultModel.embed(List.of("你好")))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("sparse-only");
+	}
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it
 This PR adds sparse embedding support to `DashScopeEmbeddingModel` for DashScope text embedding models.

  DashScope `text-embedding-v3` and `text-embedding-v4` now support `output_type` values of `dense`, `sparse`, and
  `dense&sparse`. The current Spring AI abstraction only exposes dense vectors directly, so this PR adds DashScope-
  specific support in a backward-compatible way:
  - propagates `output_type` to DashScope requests
  - parses `sparse_embedding` from DashScope responses
  - stores sparse embedding results in `EmbeddingResponseMetadata`
  - keeps dense convenience APIs safe by rejecting sparse-only output on `embed(...)` paths

  This is needed so users can access DashScope sparse and hybrid embedding capabilities through the existing DashScope
  integration.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #231
### Describe how you did it
I updated the DashScope embedding implementation in four parts:

  1. Added `outputType` support to `DashScopeEmbeddingOptions`, including constants for:
     - `dense`
     - `sparse`
     - `dense&sparse`

  2. Extended `DashScopeApiSpec` to support:
     - `output_type` in embedding request parameters
     - `sparse_embedding` in embedding responses
     - a `SparseEmbeddingItem` model for sparse vector entries

  3. Updated `DashScopeEmbeddingModel` to:
     - merge and forward `outputType` into DashScope requests
     - parse both dense and sparse embedding response fields
     - store sparse embeddings in `EmbeddingResponseMetadata` under `SPARSE_EMBEDDINGS_METADATA`
     - preserve `outputType` on the document embedding path
     - reject `outputType = sparse` for dense convenience APIs such as `embed(List<String>)` and
  `embed(List<Document>, ...)`, while keeping `call(...)` as the full-featured API

  4. Added/updated tests covering:
     - request `outputType` propagation
     - sparse embedding metadata extraction
     - dense + sparse hybrid responses
     - document embedding path preserving `outputType`
     - sparse-only rejection on dense convenience APIs

### Describe how to verify it
Run:
     ```bash
     mvn -q -pl models/dashscope "-Dtest=DashScopeEmbeddingModelTests" test
     ```
### Special notes for reviews
 - Sparse embeddings are exposed via EmbeddingResponseMetadata instead of changing the core Spring AI Embedding
    abstraction.
  - The metadata key is DashScopeEmbeddingModel.SPARSE_EMBEDDINGS_METADATA.
  - embed(...) APIs are intentionally kept dense-oriented; callers that need sparse output should use call(new
    EmbeddingRequest(...)).
