### PR TITLE
fix: Support kebab-case for mcp params

### DIFF
--- a/mcp/spring-ai-alibaba-mcp-gateway/src/main/java/com/alibaba/cloud/ai/mcp/gateway/nacos/callback/NacosMcpGatewayToolCallback.java
+++ b/mcp/spring-ai-alibaba-mcp-gateway/src/main/java/com/alibaba/cloud/ai/mcp/gateway/nacos/callback/NacosMcpGatewayToolCallback.java
@@ -80,11 +80,12 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
 
     private static final Logger logger = LoggerFactory.getLogger(NacosMcpGatewayToolCallback.class);
 
-    private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{\\{\\s*(\\.(?:[\\w]+(?:\\.[\\w]+)*)?)\\s*\\}\\}");
+    // Match {{ .args.key1 }} or {{ .args.key_2 }} or {{ .args.key-3 }}
+    private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{\\{\\s*(\\.(?:[\\w-]+(?:\\.[\\w-]+)*)?)\\s*\\}\\}");
 
-    // Match {{ ${nacos.dataId/group} }} or {{ ${nacos.dataId/group}.key1.key2 }}
+    // Match {{ ${nacos.dataId/group} }} or {{ ${nacos.dataId/group}.key1.key2 }} or {{ ${nacos.dataId/group}.key-1.key_2 }}
     private static final Pattern NACOS_TEMPLATE_PATTERN = Pattern
-            .compile("\\{\\{\\s*\\$\\{nacos\\.([^}]+)\\}(\\.[\\w]+(?:\\.[\\w]+)*)?\\s*}}");
+            .compile("\\{\\{\\s*\\$\\{nacos\\.([^}]+)\\}(\\.[\\w-]+(?:\\.[\\w-]+)*)?\\s*}}");
 
     /**
      * The Object mapper.


### PR DESCRIPTION
### Describe what this PR does / why we need it

在mcp调用参数中如果出现带`-`的参数，在请求模板中无法引用

当前现状：
```
{{ .args.token }} ✅
{{ .args.x-api-key }} ❌
```

调整后：
```
{{ .args.token }} ✅
{{ .args.x-api-key }} ✅
```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
