### PR TITLE
fix(dashscope): set stream request parameter from stream call

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -704,6 +704,7 @@ public class DashScopeChatModel implements ChatModel {
         // @formatter:off
 		// todo: sync modify by {@link ChatCompletionRequestParameter} new params.
 		Boolean incrementalOutput = stream && options.getIncrementalOutput();
+		Boolean parameterStream = stream ? Boolean.TRUE : null;
 		return new ChatCompletionRequestParameter(
                 "message",
                 options.getSeed(),
@@ -741,7 +742,7 @@ public class DashScopeChatModel implements ChatModel {
 
                 options.getTranslationOptions(),
 
-                options.getStream(),
+                parameterStream,
                 options.getStreamOptions(),
 
                 options.getModalities(),

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
@@ -594,6 +594,7 @@ class DashScopeChatModelTests {
 
         var request = chatModel.createRequest(prompt, false);
         assertThat(request.parameters().incrementalOutput()).isFalse();
+        assertThat(request.parameters().stream()).isNull();
 
         var chatResponse = chatModel.call(prompt);
         assertThat(chatResponse).isNotNull();
@@ -614,6 +615,7 @@ class DashScopeChatModelTests {
 
         var request = chatModel.createRequest(prompt, true);
         assertThat(request.parameters().incrementalOutput()).isTrue();
+        assertThat(request.parameters().stream()).isTrue();
 
         var chatResponseFlux = chatModel.stream(prompt);
         assertThat(chatResponseFlux).isNotNull();


### PR DESCRIPTION
## 背景

关联：alibaba/spring-ai-alibaba#4613

`DashScopeChatOptions.stream` 被标记为 `@JsonIgnore`，不会参与 `ModelOptionsUtils.merge(...)` 的 Jackson 复制流程。当前 `DashScopeChatModel` 虽然在 `createRequest(prompt, stream)` 中已经明确传入流式标记，但构造 `ChatCompletionRequestParameter` 时仍然读取 `options.getStream()`，导致 `parameters.stream` 在合并后可能丢失为 `null`。

## 修改内容

- `DashScopeChatModel` 构造 DashScope request parameters 时，改为使用 `createRequest(..., stream)` 的方法入参设置 `parameters.stream`。
- 非流式请求保持不输出 `parameters.stream`，避免改变同步调用的请求体语义。
- 为 `DashScopeChatModelTests` 增加断言，覆盖非流式请求 `parameters.stream == null`、流式请求 `parameters.stream == true`。

## 语义说明

这个修改不改变 `call(...)` 和 `stream(...)` 的分流入口：是否走流式 API 仍由 `ChatModel.stream(...)` 调用路径决定。

修复点只在 DashScope 请求参数层：流式请求会明确携带 `parameters.stream=true`，避免该字段依赖被 `@JsonIgnore` 排除后的 options 状态。

## 验证

- `JAVA_HOME=$HOME/.sdkman/candidates/java/21.0.10-amzn PATH=$HOME/.sdkman/candidates/java/21.0.10-amzn/bin:$PATH mvn -pl models/dashscope -Dtest=DashScopeChatModelTests test`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/21.0.10-amzn PATH=$HOME/.sdkman/candidates/java/21.0.10-amzn/bin:$PATH mvn -pl models/dashscope test`

验证结果：`Tests run: 455, Failures: 0, Errors: 0, Skipped: 30`。