### PR TITLE
Fix DashScope stream request parameter

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -704,6 +704,7 @@ public class DashScopeChatModel implements ChatModel {
         // @formatter:off
 		// todo: sync modify by {@link ChatCompletionRequestParameter} new params.
 		Boolean incrementalOutput = stream && options.getIncrementalOutput();
+		Boolean parameterStream = stream ? Boolean.TRUE : null;
 		return new ChatCompletionRequestParameter(
                 "message",
                 options.getSeed(),
@@ -741,7 +742,7 @@ public class DashScopeChatModel implements ChatModel {
 
                 options.getTranslationOptions(),
 
-                options.getStream(),
+                parameterStream,
                 options.getStreamOptions(),
 
                 options.getModalities(),

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
@@ -594,6 +594,7 @@ class DashScopeChatModelTests {
 
         var request = chatModel.createRequest(prompt, false);
         assertThat(request.parameters().incrementalOutput()).isFalse();
+        assertThat(request.parameters().stream()).isNull();
 
         var chatResponse = chatModel.call(prompt);
         assertThat(chatResponse).isNotNull();
@@ -614,6 +615,7 @@ class DashScopeChatModelTests {
 
         var request = chatModel.createRequest(prompt, true);
         assertThat(request.parameters().incrementalOutput()).isTrue();
+        assertThat(request.parameters().stream()).isTrue();
 
         var chatResponseFlux = chatModel.stream(prompt);
         assertThat(chatResponseFlux).isNotNull();


### PR DESCRIPTION
## Summary

This PR fixes DashScope chat streaming request parameter propagation.

`toDashScopeRequestParameter(...)` already receives the resolved `stream` flag from the request path, but it was still reading `options.getStream()` when building `ChatCompletionRequestParameter`. Since `DashScopeChatOptions.stream` is ignored during JSON-based option merging, that value can be lost before request creation.

The fix uses the resolved method argument for `parameters.stream`, and keeps non-streaming requests unchanged by leaving the parameter unset.

## Related Issue

Refs alibaba/spring-ai-alibaba#4613

## Validation

```bash
JAVA_HOME=/Users/viperthanks/.sdkman/candidates/java/17.0.17-tem PATH=/Users/viperthanks/.sdkman/candidates/java/17.0.17-tem/bin:$PATH mvn -pl models/dashscope -Dtest=DashScopeChatModelTests test
```

Result: `Tests run: 37, Failures: 0, Errors: 0, Skipped: 0`.
