### PR TITLE
fix(rerank): use null defaults in DashScopeRerankOptions to let yml model config take effect

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/rerank/DashScopeRerankModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/rerank/DashScopeRerankModel.java
@@ -59,7 +59,7 @@ public class DashScopeRerankModel implements RerankModel {
 	private final DashScopeRerankOptions defaultOptions;
 
 	public DashScopeRerankModel(DashScopeApi dashScopeApi) {
-		this(dashScopeApi, DashScopeRerankOptions.builder().build());
+		this(dashScopeApi, DashScopeRerankOptions.builder().model("gte-rerank").topN(3).returnDocuments(false).build());
 	}
 
 	public DashScopeRerankModel(DashScopeApi dashScopeApi, DashScopeRerankOptions defaultOptions) {
@@ -158,7 +158,8 @@ public class DashScopeRerankModel implements RerankModel {
 
         private DashScopeApi dashScopeApi;
 
-        private DashScopeRerankOptions defaultOptions = DashScopeRerankOptions.builder().build();
+        private DashScopeRerankOptions defaultOptions = DashScopeRerankOptions.builder()
+                .model("gte-rerank").topN(3).returnDocuments(false).build();
 
         private RetryTemplate retryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE;
 

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/rerank/DashScopeRerankOptions.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/rerank/DashScopeRerankOptions.java
@@ -28,13 +28,13 @@ import com.alibaba.cloud.ai.model.RerankOptions;
 public class DashScopeRerankOptions implements RerankOptions {
 
   /** ID of the model to use. */
-  private String model = "gte-rerank";
+  private String model;
 
   /** return top n best relevant docs for query */
-  private Integer topN = 3;
+  private Integer topN;
 
   /** if need to return original document */
-  private Boolean returnDocuments = false;
+  private Boolean returnDocuments;
 
   @Override
   public String getModel() {

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/rerank/DashScopeRerankOptionsTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/rerank/DashScopeRerankOptionsTests.java
@@ -38,17 +38,17 @@ class DashScopeRerankOptionsTests {
 	private static final Boolean TEST_RETURN_DOCUMENTS = true;
 
 	/**
-	 * Test default values of DashScopeRerankOptions. Verifies that a newly created
-	 * instance has the expected default values: - model = "gte-rerank" - topN = 3 -
-	 * returnDocuments = false
+	 * Test that an empty builder produces null fields. All fields default to null so that
+	 * ModelOptionsUtils.mergeOption() correctly falls through to the configured defaults
+	 * rather than having constructor values silently override them.
 	 */
 	@Test
 	void testDefaultValues() {
 		DashScopeRerankOptions options = DashScopeRerankOptions.builder().build();
 
-		assertThat(options.getModel()).isEqualTo("gte-rerank");
-		assertThat(options.getTopN()).isEqualTo(3);
-		assertThat(options.getReturnDocuments()).isFalse();
+		assertThat(options.getModel()).isNull();
+		assertThat(options.getTopN()).isNull();
+		assertThat(options.getReturnDocuments()).isNull();
 	}
 
 	/**
@@ -86,8 +86,8 @@ class DashScopeRerankOptionsTests {
 	}
 
 	/**
-	 * Test builder with partial values set. Verifies that when only some properties are
-	 * set using the builder, the unset properties retain their default values.
+	 * Test builder with partial values set. Unset fields remain null so they do not
+	 * accidentally override configured defaults during options merging.
 	 */
 	@Test
 	void testBuilderWithPartialValues() {
@@ -98,7 +98,33 @@ class DashScopeRerankOptionsTests {
 
 		assertThat(options.getModel()).isEqualTo(TEST_MODEL);
 		assertThat(options.getTopN()).isEqualTo(TEST_TOP_N);
-		assertThat(options.getReturnDocuments()).isFalse(); // Default value
+		assertThat(options.getReturnDocuments()).isNull();
+	}
+
+	/**
+	 * Test that null fields in runtime options fall through to the configured default.
+	 * This is the core contract that prevents hardcoded constructor values from silently
+	 * overriding yml-configured model names when merging options.
+	 */
+	@Test
+	void testNullFieldsFallThroughToDefault() {
+		DashScopeRerankOptions configuredDefaults = DashScopeRerankOptions.builder()
+			.model("gte-rerank-v2")
+			.topN(10)
+			.returnDocuments(true)
+			.build();
+
+		// Runtime options with only topN set — model and returnDocuments are null
+		DashScopeRerankOptions runtimeOptions = DashScopeRerankOptions.builder().topN(5).build();
+
+		String mergedModel = runtimeOptions.getModel() != null ? runtimeOptions.getModel() : configuredDefaults.getModel();
+		Integer mergedTopN = runtimeOptions.getTopN() != null ? runtimeOptions.getTopN() : configuredDefaults.getTopN();
+		Boolean mergedReturnDocs = runtimeOptions.getReturnDocuments() != null ? runtimeOptions.getReturnDocuments()
+				: configuredDefaults.getReturnDocuments();
+
+		assertThat(mergedModel).isEqualTo("gte-rerank-v2");
+		assertThat(mergedTopN).isEqualTo(5);
+		assertThat(mergedReturnDocs).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
### Describe what this PR does / why we need it

`DashScopeRerankOptions` had non-null field defaults (`model="gte-rerank"`, `topN=3`, `returnDocuments=false`).
When a caller passed **partial** runtime options — for example only specifying `topN` and `returnDocuments` without an explicit model — the constructor-initialized `model="gte-rerank"` was non-null, so `ModelOptionsUtils.mergeOption()` returned it in preference to the value the user had configured via `spring.ai.dashscope.rerank.options.model` in `application.yml`.

This caused **silent failure**: the configured model was completely ignored and requests always used the hard-coded default `gte-rerank`, with no warning or exception.

**Root cause trace:**

```
// Runtime options created without specifying model:
DashScopeRerankOptions.builder().topN(4).returnDocuments(true).build()
// -> model = "gte-rerank"  (from field initializer, non-null!)

// In DashScopeRerankModel.mergeOptions():
ModelOptionsUtils.mergeOption(
    runtimeOptions.getModel(),   // "gte-rerank"  <- wins (non-null)
    defaultOptions.getModel()    // "gte-rerank-v2" <- ignored
)
// Result: "gte-rerank"  — yml config silently discarded
```

**Fix:** Remove the hardcoded field defaults from `DashScopeRerankOptions` (set to `null`). The meaningful defaults now live exclusively in `DashScopeRerankModel` (no-arg constructor and `Builder`) and in `DashScopeRerankProperties`, where they are set explicitly via `.model("gte-rerank")`.

This follows the same convention used by other Spring AI options classes (e.g. `OpenAiChatOptions`), where options fields default to `null` so the merge step works correctly.

### Does this pull request fix one issue?

Fixes alibaba/spring-ai-alibaba#4663

### Changes

| File | Change |
|------|--------|
| `DashScopeRerankOptions.java` | Remove hardcoded defaults from `model`, `topN`, `returnDocuments` fields |
| `DashScopeRerankModel.java` | Explicit defaults in no-arg constructor and `Builder` field initializer |
| `DashScopeRerankOptionsTests.java` | Update tests to expect `null` from empty builder; add `testNullFieldsFallThroughToDefault` |

### How to verify

Configure a non-default rerank model in `application.yml`:
```yaml
spring:
  ai:
    dashscope:
      rerank:
        options:
          model: gte-rerank-v2
```
Call `DashScopeRerankModel` with partial runtime options (topN only). Before this fix the request goes to `gte-rerank`; after this fix it correctly uses `gte-rerank-v2`.