### PR TITLE
[codex] Adapt DashScope audio options to Spring AI 2.0

### DIFF
--- a/models/spring-ai-alibaba-dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeAudioTranscriptionOptions.java
+++ b/models/spring-ai-alibaba-dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeAudioTranscriptionOptions.java
@@ -462,7 +462,31 @@ public class DashScopeAudioTranscriptionOptions implements AudioTranscriptionOpt
 				+ ", asrOptions=" + this.asrOptions + '}';
 	}
 
-	public static class Builder {
+	public static final class Builder extends AbstractBuilder<DashScopeAudioTranscriptionOptions, Builder> {
+
+		@Override
+		protected Builder self() {
+			return this;
+		}
+
+        // @formatter:off
+		public DashScopeAudioTranscriptionOptions build() {
+			return new DashScopeAudioTranscriptionOptions(this.model, this.vocabularyId, this.sampleRate, this.format,
+					this.sourceLanguage, this.transcriptionEnabled, this.translationEnabled,
+					this.translationTargetLanguages, this.maxEndSilence, this.modalities, this.audio, this.stream,
+					this.streamOptions, this.maxTokens, this.seed, this.temperature, this.topP,
+					this.presencePenalty, this.topK, this.repetitionPenalty, this.translationOptions,
+					this.disfluencyRemovalEnabled, this.languageHints, this.semanticPunctuationEnabled,
+					this.maxSentenceSilence, this.multiThresholdModeEnabled, this.punctuationPredictionEnabled,
+					this.heartbeat, this.inverseTextNormalizationEnabled, this.resources,
+					this.timestampAlignmentEnabled, this.specialWordFilter, this.diarizationEnabled,
+					this.speakerCount, this.channelId, this.asrOptions);
+		}
+        // @formatter:on
+
+	}
+
+	protected abstract static class AbstractBuilder<O extends DashScopeAudioTranscriptionOptions, B extends AbstractBuilder<O, B>> {
 
 		protected @Nullable String model;
 
@@ -536,190 +560,192 @@ public class DashScopeAudioTranscriptionOptions implements AudioTranscriptionOpt
 
 		protected @Nullable AsrOptions asrOptions;
 
-		public Builder() {
+		protected AbstractBuilder() {
 		}
 
-		public Builder model(@Nullable String model) {
+		protected abstract B self();
+
+		public B model(@Nullable String model) {
 			this.model = model;
-			return this;
+			return self();
 		}
 
-		public Builder vocabularyId(@Nullable String vocabularyId) {
+		public B vocabularyId(@Nullable String vocabularyId) {
 			this.vocabularyId = vocabularyId;
-			return this;
+			return self();
 		}
 
-		public Builder sampleRate(@Nullable Integer sampleRate) {
+		public B sampleRate(@Nullable Integer sampleRate) {
 			this.sampleRate = sampleRate;
-			return this;
+			return self();
 		}
 
-		public Builder format(@Nullable String format) {
+		public B format(@Nullable String format) {
 			this.format = format;
-			return this;
+			return self();
 		}
 
-		public Builder sourceLanguage(@Nullable String sourceLanguage) {
+		public B sourceLanguage(@Nullable String sourceLanguage) {
 			this.sourceLanguage = sourceLanguage;
-			return this;
+			return self();
 		}
 
-		public Builder transcriptionEnabled(@Nullable Boolean transcriptionEnabled) {
+		public B transcriptionEnabled(@Nullable Boolean transcriptionEnabled) {
 			this.transcriptionEnabled = transcriptionEnabled;
-			return this;
+			return self();
 		}
 
-		public Builder translationEnabled(@Nullable Boolean translationEnabled) {
+		public B translationEnabled(@Nullable Boolean translationEnabled) {
 			this.translationEnabled = translationEnabled;
-			return this;
+			return self();
 		}
 
-		public Builder translationTargetLanguages(@Nullable List<String> translationTargetLanguages) {
+		public B translationTargetLanguages(@Nullable List<String> translationTargetLanguages) {
 			this.translationTargetLanguages = translationTargetLanguages;
-			return this;
+			return self();
 		}
 
-		public Builder maxEndSilence(@Nullable Integer maxEndSilence) {
+		public B maxEndSilence(@Nullable Integer maxEndSilence) {
 			this.maxEndSilence = maxEndSilence;
-			return this;
+			return self();
 		}
 
-		public Builder modalities(@Nullable List<String> modalities) {
+		public B modalities(@Nullable List<String> modalities) {
 			this.modalities = modalities;
-			return this;
+			return self();
 		}
 
-		public Builder audio(@Nullable Audio audio) {
+		public B audio(@Nullable Audio audio) {
 			this.audio = audio;
-			return this;
+			return self();
 		}
 
-		public Builder stream(@Nullable Boolean stream) {
+		public B stream(@Nullable Boolean stream) {
 			this.stream = stream;
-			return this;
+			return self();
 		}
 
-		public Builder streamOptions(@Nullable StreamOptions streamOptions) {
+		public B streamOptions(@Nullable StreamOptions streamOptions) {
 			this.streamOptions = streamOptions;
-			return this;
+			return self();
 		}
 
-		public Builder maxTokens(@Nullable Integer maxTokens) {
+		public B maxTokens(@Nullable Integer maxTokens) {
 			this.maxTokens = maxTokens;
-			return this;
+			return self();
 		}
 
-		public Builder seed(@Nullable Integer seed) {
+		public B seed(@Nullable Integer seed) {
 			this.seed = seed;
-			return this;
+			return self();
 		}
 
-		public Builder temperature(@Nullable Float temperature) {
+		public B temperature(@Nullable Float temperature) {
 			this.temperature = temperature;
-			return this;
+			return self();
 		}
 
-		public Builder topP(@Nullable Float topP) {
+		public B topP(@Nullable Float topP) {
 			this.topP = topP;
-			return this;
+			return self();
 		}
 
-		public Builder presencePenalty(@Nullable Float presencePenalty) {
+		public B presencePenalty(@Nullable Float presencePenalty) {
 			this.presencePenalty = presencePenalty;
-			return this;
+			return self();
 		}
 
-		public Builder topK(@Nullable Integer topK) {
+		public B topK(@Nullable Integer topK) {
 			this.topK = topK;
-			return this;
+			return self();
 		}
 
-		public Builder repetitionPenalty(@Nullable Float repetitionPenalty) {
+		public B repetitionPenalty(@Nullable Float repetitionPenalty) {
 			this.repetitionPenalty = repetitionPenalty;
-			return this;
+			return self();
 		}
 
-		public Builder translationOptions(@Nullable TranslationOptions translationOptions) {
+		public B translationOptions(@Nullable TranslationOptions translationOptions) {
 			this.translationOptions = translationOptions;
-			return this;
+			return self();
 		}
 
-		public Builder disfluencyRemovalEnabled(@Nullable Boolean disfluencyRemovalEnabled) {
+		public B disfluencyRemovalEnabled(@Nullable Boolean disfluencyRemovalEnabled) {
 			this.disfluencyRemovalEnabled = disfluencyRemovalEnabled;
-			return this;
+			return self();
 		}
 
-		public Builder languageHints(@Nullable List<String> languageHints) {
+		public B languageHints(@Nullable List<String> languageHints) {
 			this.languageHints = languageHints;
-			return this;
+			return self();
 		}
 
-		public Builder semanticPunctuationEnabled(@Nullable Boolean semanticPunctuationEnabled) {
+		public B semanticPunctuationEnabled(@Nullable Boolean semanticPunctuationEnabled) {
 			this.semanticPunctuationEnabled = semanticPunctuationEnabled;
-			return this;
+			return self();
 		}
 
-		public Builder maxSentenceSilence(@Nullable Integer maxSentenceSilence) {
+		public B maxSentenceSilence(@Nullable Integer maxSentenceSilence) {
 			this.maxSentenceSilence = maxSentenceSilence;
-			return this;
+			return self();
 		}
 
-		public Builder multiThresholdModeEnabled(@Nullable Boolean multiThresholdModeEnabled) {
+		public B multiThresholdModeEnabled(@Nullable Boolean multiThresholdModeEnabled) {
 			this.multiThresholdModeEnabled = multiThresholdModeEnabled;
-			return this;
+			return self();
 		}
 
-		public Builder punctuationPredictionEnabled(@Nullable Boolean punctuationPredictionEnabled) {
+		public B punctuationPredictionEnabled(@Nullable Boolean punctuationPredictionEnabled) {
 			this.punctuationPredictionEnabled = punctuationPredictionEnabled;
-			return this;
+			return self();
 		}
 
-		public Builder heartbeat(@Nullable Boolean heartbeat) {
+		public B heartbeat(@Nullable Boolean heartbeat) {
 			this.heartbeat = heartbeat;
-			return this;
+			return self();
 		}
 
-		public Builder inverseTextNormalizationEnabled(@Nullable Boolean inverseTextNormalizationEnabled) {
+		public B inverseTextNormalizationEnabled(@Nullable Boolean inverseTextNormalizationEnabled) {
 			this.inverseTextNormalizationEnabled = inverseTextNormalizationEnabled;
-			return this;
+			return self();
 		}
 
-		public Builder resources(@Nullable List<Resource> resources) {
+		public B resources(@Nullable List<Resource> resources) {
 			this.resources = resources;
-			return this;
+			return self();
 		}
 
-		public Builder timestampAlignmentEnabled(@Nullable Boolean timestampAlignmentEnabled) {
+		public B timestampAlignmentEnabled(@Nullable Boolean timestampAlignmentEnabled) {
 			this.timestampAlignmentEnabled = timestampAlignmentEnabled;
-			return this;
+			return self();
 		}
 
-		public Builder specialWordFilter(@Nullable String specialWordFilter) {
+		public B specialWordFilter(@Nullable String specialWordFilter) {
 			this.specialWordFilter = specialWordFilter;
-			return this;
+			return self();
 		}
 
-		public Builder diarizationEnabled(@Nullable Boolean diarizationEnabled) {
+		public B diarizationEnabled(@Nullable Boolean diarizationEnabled) {
 			this.diarizationEnabled = diarizationEnabled;
-			return this;
+			return self();
 		}
 
-		public Builder speakerCount(@Nullable Integer speakerCount) {
+		public B speakerCount(@Nullable Integer speakerCount) {
 			this.speakerCount = speakerCount;
-			return this;
+			return self();
 		}
 
-		public Builder channelId(@Nullable List<Integer> channelId) {
+		public B channelId(@Nullable List<Integer> channelId) {
 			this.channelId = channelId;
-			return this;
+			return self();
 		}
 
-		public Builder asrOptions(@Nullable AsrOptions asrOptions) {
+		public B asrOptions(@Nullable AsrOptions asrOptions) {
 			this.asrOptions = asrOptions;
-			return this;
+			return self();
 		}
 
-		public Builder from(DashScopeAudioTranscriptionOptions fromOptions) {
+		public B from(DashScopeAudioTranscriptionOptions fromOptions) {
 			this.model = fromOptions.getModel();
 			this.vocabularyId = fromOptions.getVocabularyId();
 			this.sampleRate = fromOptions.getSampleRate();
@@ -756,12 +782,12 @@ public class DashScopeAudioTranscriptionOptions implements AudioTranscriptionOpt
 			this.speakerCount = fromOptions.getSpeakerCount();
 			this.channelId = fromOptions.getChannelId();
 			this.asrOptions = fromOptions.getAsrOptions();
-			return this;
+			return self();
 		}
 
-		public Builder merge(@Nullable AudioTranscriptionOptions from) {
+		public B merge(@Nullable AudioTranscriptionOptions from) {
 			if (from == null) {
-				return this;
+				return self();
 			}
 			this.model = from.getModel();
 			if (from instanceof DashScopeAudioTranscriptionOptions castFrom) {
@@ -871,23 +897,8 @@ public class DashScopeAudioTranscriptionOptions implements AudioTranscriptionOpt
 					this.asrOptions = castFrom.getAsrOptions();
 				}
 			}
-			return this;
+			return self();
 		}
-
-        // @formatter:off
-		public DashScopeAudioTranscriptionOptions build() {
-			return new DashScopeAudioTranscriptionOptions(this.model, this.vocabularyId, this.sampleRate, this.format,
-					this.sourceLanguage, this.transcriptionEnabled, this.translationEnabled,
-					this.translationTargetLanguages, this.maxEndSilence, this.modalities, this.audio, this.stream,
-					this.streamOptions, this.maxTokens, this.seed, this.temperature, this.topP,
-					this.presencePenalty, this.topK, this.repetitionPenalty, this.translationOptions,
-					this.disfluencyRemovalEnabled, this.languageHints, this.semanticPunctuationEnabled,
-					this.maxSentenceSilence, this.multiThresholdModeEnabled, this.punctuationPredictionEnabled,
-					this.heartbeat, this.inverseTextNormalizationEnabled, this.resources,
-					this.timestampAlignmentEnabled, this.specialWordFilter, this.diarizationEnabled,
-					this.speakerCount, this.channelId, this.asrOptions);
-		}
-        // @formatter:on
 
 	}
 

--- a/models/spring-ai-alibaba-dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeAudioTranscriptionOptions.java
+++ b/models/spring-ai-alibaba-dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeAudioTranscriptionOptions.java
@@ -15,7 +15,6 @@
  */
 package com.alibaba.cloud.ai.dashscope.audio.transcription;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -166,9 +165,9 @@ public class DashScopeAudioTranscriptionOptions implements AudioTranscriptionOpt
 		this.sourceLanguage = sourceLanguage;
 		this.transcriptionEnabled = transcriptionEnabled;
 		this.translationEnabled = translationEnabled;
-		this.translationTargetLanguages = translationTargetLanguages != null ? new ArrayList<>(translationTargetLanguages) : null;
+		this.translationTargetLanguages = translationTargetLanguages != null ? List.copyOf(translationTargetLanguages) : null;
 		this.maxEndSilence = maxEndSilence;
-		this.modalities = modalities != null ? new ArrayList<>(modalities) : null;
+		this.modalities = modalities != null ? List.copyOf(modalities) : null;
 		this.audio = audio;
 		this.stream = stream;
 		this.streamOptions = streamOptions;
@@ -181,19 +180,19 @@ public class DashScopeAudioTranscriptionOptions implements AudioTranscriptionOpt
 		this.repetitionPenalty = repetitionPenalty;
 		this.translationOptions = translationOptions;
 		this.disfluencyRemovalEnabled = disfluencyRemovalEnabled;
-		this.languageHints = languageHints != null ? new ArrayList<>(languageHints) : null;
+		this.languageHints = languageHints != null ? List.copyOf(languageHints) : null;
 		this.semanticPunctuationEnabled = semanticPunctuationEnabled;
 		this.maxSentenceSilence = maxSentenceSilence;
 		this.multiThresholdModeEnabled = multiThresholdModeEnabled;
 		this.punctuationPredictionEnabled = punctuationPredictionEnabled;
 		this.heartbeat = heartbeat;
 		this.inverseTextNormalizationEnabled = inverseTextNormalizationEnabled;
-		this.resources = resources != null ? new ArrayList<>(resources) : null;
+		this.resources = resources != null ? List.copyOf(resources) : null;
 		this.timestampAlignmentEnabled = timestampAlignmentEnabled;
 		this.specialWordFilter = specialWordFilter;
 		this.diarizationEnabled = diarizationEnabled;
 		this.speakerCount = speakerCount;
-		this.channelId = channelId != null ? new ArrayList<>(channelId) : null;
+		this.channelId = channelId != null ? List.copyOf(channelId) : null;
 		this.asrOptions = asrOptions;
 	}
 
@@ -344,10 +343,6 @@ public class DashScopeAudioTranscriptionOptions implements AudioTranscriptionOpt
 
 	public static Builder builder() {
 		return new Builder();
-	}
-
-	public static DashScopeAudioTranscriptionOptions fromOptions(DashScopeAudioTranscriptionOptions options) {
-		return options.mutate().build();
 	}
 
 	public Builder mutate() {
@@ -768,9 +763,7 @@ public class DashScopeAudioTranscriptionOptions implements AudioTranscriptionOpt
 			if (from == null) {
 				return this;
 			}
-			if (from.getModel() != null) {
-				this.model = from.getModel();
-			}
+			this.model = from.getModel();
 			if (from instanceof DashScopeAudioTranscriptionOptions castFrom) {
 				if (castFrom.getVocabularyId() != null) {
 					this.vocabularyId = castFrom.getVocabularyId();

--- a/models/spring-ai-alibaba-dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/tts/DashScopeAudioSpeechOptions.java
+++ b/models/spring-ai-alibaba-dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/tts/DashScopeAudioSpeechOptions.java
@@ -303,7 +303,28 @@ public class DashScopeAudioSpeechOptions implements TextToSpeechOptions {
 	/**
 	 * Builder for DashScopeAudioSpeechOptions.
 	 */
-	public static class Builder implements TextToSpeechOptions.Builder {
+	public static final class Builder extends AbstractBuilder<DashScopeAudioSpeechOptions, Builder> {
+
+		@Override
+		protected Builder self() {
+			return this;
+		}
+
+        // @formatter:off
+		@Override
+		public DashScopeAudioSpeechOptions build() {
+			return new DashScopeAudioSpeechOptions(this.model, this.textType, this.voice, this.format, this.sampleRate,
+					this.volume, this.rate, this.pitch, this.enableSsml, this.bitRate, this.speed, this.seed,
+					this.wordTimestampEnabled, this.phonemeTimestampEnabled, this.languageHints, this.instruction,
+					this.optimizeInstructions, this.enableAigcTag, this.aigcPropagator, this.aigcPropagateId,
+					this.languageType);
+		}
+        // @formatter:on
+
+	}
+
+	protected abstract static class AbstractBuilder<O extends DashScopeAudioSpeechOptions, B extends AbstractBuilder<O, B>>
+			implements TextToSpeechOptions.Builder {
 
 		protected @Nullable String model;
 
@@ -347,120 +368,122 @@ public class DashScopeAudioSpeechOptions implements TextToSpeechOptions {
 
 		protected @Nullable String languageType;
 
-		public Builder() {
+		protected AbstractBuilder() {
 		}
 
+		protected abstract B self();
+
 		@Override
-		public Builder model(@Nullable String model) {
+		public B model(@Nullable String model) {
 			this.model = model;
-			return this;
+			return self();
 		}
 
-		public Builder textType(@Nullable String textType) {
+		public B textType(@Nullable String textType) {
 			this.textType = textType;
-			return this;
+			return self();
 		}
 
 		@Override
-		public Builder voice(@Nullable String voice) {
+		public B voice(@Nullable String voice) {
 			this.voice = voice;
-			return this;
+			return self();
 		}
 
 		@Override
-		public Builder format(@Nullable String format) {
+		public B format(@Nullable String format) {
 			this.format = format;
-			return this;
+			return self();
 		}
 
-		public Builder sampleRate(@Nullable Integer sampleRate) {
+		public B sampleRate(@Nullable Integer sampleRate) {
 			this.sampleRate = sampleRate;
-			return this;
+			return self();
 		}
 
-		public Builder volume(@Nullable Integer volume) {
+		public B volume(@Nullable Integer volume) {
 			this.volume = volume;
-			return this;
+			return self();
 		}
 
-		public Builder rate(@Nullable Float rate) {
+		public B rate(@Nullable Float rate) {
 			this.rate = rate;
-			return this;
+			return self();
 		}
 
-		public Builder pitch(@Nullable Float pitch) {
+		public B pitch(@Nullable Float pitch) {
 			this.pitch = pitch;
-			return this;
+			return self();
 		}
 
-		public Builder enableSsml(@Nullable Boolean enableSsml) {
+		public B enableSsml(@Nullable Boolean enableSsml) {
 			this.enableSsml = enableSsml;
-			return this;
+			return self();
 		}
 
-		public Builder bitRate(@Nullable Integer bitRate) {
+		public B bitRate(@Nullable Integer bitRate) {
 			this.bitRate = bitRate;
-			return this;
+			return self();
 		}
 
 		@Override
-		public Builder speed(@Nullable Double speed) {
+		public B speed(@Nullable Double speed) {
 			this.speed = speed;
-			return this;
+			return self();
 		}
 
-		public Builder seed(@Nullable Integer seed) {
+		public B seed(@Nullable Integer seed) {
 			this.seed = seed;
-			return this;
+			return self();
 		}
 
-		public Builder wordTimestampEnabled(@Nullable Boolean wordTimestampEnabled) {
+		public B wordTimestampEnabled(@Nullable Boolean wordTimestampEnabled) {
 			this.wordTimestampEnabled = wordTimestampEnabled;
-			return this;
+			return self();
 		}
 
-		public Builder phonemeTimestampEnabled(@Nullable Boolean phonemeTimestampEnabled) {
+		public B phonemeTimestampEnabled(@Nullable Boolean phonemeTimestampEnabled) {
 			this.phonemeTimestampEnabled = phonemeTimestampEnabled;
-			return this;
+			return self();
 		}
 
-		public Builder languageHints(@Nullable List<String> languageHints) {
+		public B languageHints(@Nullable List<String> languageHints) {
 			this.languageHints = languageHints;
-			return this;
+			return self();
 		}
 
-		public Builder instruction(@Nullable String instruction) {
+		public B instruction(@Nullable String instruction) {
 			this.instruction = instruction;
-			return this;
+			return self();
 		}
 
-		public Builder optimizeInstructions(@Nullable Boolean optimizeInstructions) {
+		public B optimizeInstructions(@Nullable Boolean optimizeInstructions) {
 			this.optimizeInstructions = optimizeInstructions;
-			return this;
+			return self();
 		}
 
-		public Builder enableAigcTag(@Nullable Boolean enableAigcTag) {
+		public B enableAigcTag(@Nullable Boolean enableAigcTag) {
 			this.enableAigcTag = enableAigcTag;
-			return this;
+			return self();
 		}
 
-		public Builder aigcPropagator(@Nullable String aigcPropagator) {
+		public B aigcPropagator(@Nullable String aigcPropagator) {
 			this.aigcPropagator = aigcPropagator;
-			return this;
+			return self();
 		}
 
-		public Builder aigcPropagateId(@Nullable String aigcPropagateId) {
+		public B aigcPropagateId(@Nullable String aigcPropagateId) {
 			this.aigcPropagateId = aigcPropagateId;
-			return this;
+			return self();
 		}
 
-		public Builder languageType(@Nullable String languageType) {
+		public B languageType(@Nullable String languageType) {
 			this.languageType = languageType;
-			return this;
+			return self();
 		}
 
         // @formatter:off
-		public Builder from(DashScopeAudioSpeechOptions fromOptions) {
+		public B from(DashScopeAudioSpeechOptions fromOptions) {
 			this.model = fromOptions.getModel();
 			this.textType = fromOptions.getTextType();
 			this.voice = fromOptions.getVoice();
@@ -482,13 +505,13 @@ public class DashScopeAudioSpeechOptions implements TextToSpeechOptions {
 			this.aigcPropagator = fromOptions.getAigcPropagator();
 			this.aigcPropagateId = fromOptions.getAigcPropagateId();
 			this.languageType = fromOptions.getLanguageType();
-			return this;
+			return self();
 		}
         // @formatter:on
 
-		public Builder merge(@Nullable TextToSpeechOptions from) {
+		public B merge(@Nullable TextToSpeechOptions from) {
 			if (from == null) {
-				return this;
+				return self();
 			}
 			if (from.getModel() != null) {
 				this.model = from.getModel();
@@ -555,19 +578,8 @@ public class DashScopeAudioSpeechOptions implements TextToSpeechOptions {
 					this.languageType = castFrom.getLanguageType();
 				}
 			}
-			return this;
+			return self();
 		}
-
-        // @formatter:off
-		@Override
-		public DashScopeAudioSpeechOptions build() {
-			return new DashScopeAudioSpeechOptions(this.model, this.textType, this.voice, this.format, this.sampleRate,
-					this.volume, this.rate, this.pitch, this.enableSsml, this.bitRate, this.speed, this.seed,
-					this.wordTimestampEnabled, this.phonemeTimestampEnabled, this.languageHints, this.instruction,
-					this.optimizeInstructions, this.enableAigcTag, this.aigcPropagator, this.aigcPropagateId,
-					this.languageType);
-		}
-        // @formatter:on
 
 	}
 

--- a/models/spring-ai-alibaba-dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/tts/DashScopeAudioSpeechOptions.java
+++ b/models/spring-ai-alibaba-dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/tts/DashScopeAudioSpeechOptions.java
@@ -15,7 +15,6 @@
  */
 package com.alibaba.cloud.ai.dashscope.audio.tts;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -120,7 +119,7 @@ public class DashScopeAudioSpeechOptions implements TextToSpeechOptions {
 		this.seed = seed;
 		this.wordTimestampEnabled = wordTimestampEnabled;
 		this.phonemeTimestampEnabled = phonemeTimestampEnabled;
-		this.languageHints = languageHints != null ? new ArrayList<>(languageHints) : null;
+		this.languageHints = languageHints != null ? List.copyOf(languageHints) : null;
 		this.instruction = instruction;
 		this.optimizeInstructions = optimizeInstructions;
 		this.enableAigcTag = enableAigcTag;
@@ -247,10 +246,6 @@ public class DashScopeAudioSpeechOptions implements TextToSpeechOptions {
                 .languageType(this.languageType);
     }
 
-    public static DashScopeAudioSpeechOptions fromOptions(DashScopeAudioSpeechOptions options) {
-        return options.mutate().build();
-    }
-
     public static Builder builder() {
         return new Builder();
     }
@@ -308,7 +303,7 @@ public class DashScopeAudioSpeechOptions implements TextToSpeechOptions {
 	/**
 	 * Builder for DashScopeAudioSpeechOptions.
 	 */
-	public static class Builder {
+	public static class Builder implements TextToSpeechOptions.Builder {
 
 		protected @Nullable String model;
 
@@ -355,6 +350,7 @@ public class DashScopeAudioSpeechOptions implements TextToSpeechOptions {
 		public Builder() {
 		}
 
+		@Override
 		public Builder model(@Nullable String model) {
 			this.model = model;
 			return this;
@@ -365,11 +361,13 @@ public class DashScopeAudioSpeechOptions implements TextToSpeechOptions {
 			return this;
 		}
 
+		@Override
 		public Builder voice(@Nullable String voice) {
 			this.voice = voice;
 			return this;
 		}
 
+		@Override
 		public Builder format(@Nullable String format) {
 			this.format = format;
 			return this;
@@ -405,6 +403,7 @@ public class DashScopeAudioSpeechOptions implements TextToSpeechOptions {
 			return this;
 		}
 
+		@Override
 		public Builder speed(@Nullable Double speed) {
 			this.speed = speed;
 			return this;
@@ -560,6 +559,7 @@ public class DashScopeAudioSpeechOptions implements TextToSpeechOptions {
 		}
 
         // @formatter:off
+		@Override
 		public DashScopeAudioSpeechOptions build() {
 			return new DashScopeAudioSpeechOptions(this.model, this.textType, this.voice, this.format, this.sampleRate,
 					this.volume, this.rate, this.pitch, this.enableSsml, this.bitRate, this.speed, this.seed,

--- a/models/spring-ai-alibaba-dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeAudioTranscriptionOptionsTests.java
+++ b/models/spring-ai-alibaba-dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeAudioTranscriptionOptionsTests.java
@@ -17,9 +17,13 @@ package com.alibaba.cloud.ai.dashscope.audio.transcription;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.ai.audio.transcription.AudioTranscriptionOptions;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class DashScopeAudioTranscriptionOptionsTests {
 
@@ -117,6 +121,89 @@ class DashScopeAudioTranscriptionOptionsTests {
                 new DashScopeAudioTranscriptionOptions.TranslationOptions("en", "zh");
         assertThat(translationOptions.getSourceLang()).isEqualTo("en");
         assertThat(translationOptions.getTargetLang()).isEqualTo("zh");
+    }
+
+    @Test
+    void testMergeGenericAudioTranscriptionOptionsAppliesModelOnly() {
+        DashScopeAudioTranscriptionOptions defaultOptions = DashScopeAudioTranscriptionOptions.builder()
+                .model("gummy-realtime-v1")
+                .vocabularyId("vocab-1")
+                .sampleRate(16000)
+                .format("pcm")
+                .languageHints(List.of("zh"))
+                .build();
+        AudioTranscriptionOptions requestOptions = new AudioTranscriptionOptions() {
+            @Override
+            public String getModel() {
+                return "paraformer-realtime-v2";
+            }
+        };
+
+        DashScopeAudioTranscriptionOptions merged = DashScopeAudioTranscriptionOptions.builder()
+                .from(defaultOptions)
+                .merge(requestOptions)
+                .build();
+
+        assertThat(merged.getModel()).isEqualTo("paraformer-realtime-v2");
+        assertThat(merged.getVocabularyId()).isEqualTo("vocab-1");
+        assertThat(merged.getSampleRate()).isEqualTo(16000);
+        assertThat(merged.getFormat()).isEqualTo("pcm");
+        assertThat(merged.getLanguageHints()).containsExactly("zh");
+    }
+
+    @Test
+    void testMergeDashScopeOptionsAppliesProviderSpecificFields() {
+        DashScopeAudioTranscriptionOptions defaultOptions = DashScopeAudioTranscriptionOptions.builder()
+                .model("gummy-realtime-v1")
+                .vocabularyId("vocab-1")
+                .sampleRate(16000)
+                .format("pcm")
+                .languageHints(List.of("zh"))
+                .build();
+        DashScopeAudioTranscriptionOptions requestOptions = DashScopeAudioTranscriptionOptions.builder()
+                .model("paraformer-realtime-v2")
+                .vocabularyId("vocab-2")
+                .sampleRate(8000)
+                .format("wav")
+                .languageHints(List.of("en"))
+                .build();
+
+        DashScopeAudioTranscriptionOptions merged = DashScopeAudioTranscriptionOptions.builder()
+                .from(defaultOptions)
+                .merge(requestOptions)
+                .build();
+
+        assertThat(merged.getModel()).isEqualTo("paraformer-realtime-v2");
+        assertThat(merged.getVocabularyId()).isEqualTo("vocab-2");
+        assertThat(merged.getSampleRate()).isEqualTo(8000);
+        assertThat(merged.getFormat()).isEqualTo("wav");
+        assertThat(merged.getLanguageHints()).containsExactly("en");
+    }
+
+    @Test
+    void testListFieldsAreDefensivelyCopiedAndImmutable() {
+        List<String> languageHints = new ArrayList<>(List.of("zh"));
+        List<String> modalities = new ArrayList<>(List.of("text"));
+        List<Integer> channelId = new ArrayList<>(List.of(0));
+
+        DashScopeAudioTranscriptionOptions options = DashScopeAudioTranscriptionOptions.builder()
+                .languageHints(languageHints)
+                .modalities(modalities)
+                .channelId(channelId)
+                .build();
+        languageHints.add("en");
+        modalities.add("audio");
+        channelId.add(1);
+
+        assertThat(options.getLanguageHints()).containsExactly("zh");
+        assertThat(options.getModalities()).containsExactly("text");
+        assertThat(options.getChannelId()).containsExactly(0);
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> options.getLanguageHints().add("ja"));
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> options.getModalities().add("audio"));
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> options.getChannelId().add(1));
     }
 
 }

--- a/models/spring-ai-alibaba-dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeAudioTranscriptionOptionsTests.java
+++ b/models/spring-ai-alibaba-dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeAudioTranscriptionOptionsTests.java
@@ -17,6 +17,9 @@ package com.alibaba.cloud.ai.dashscope.audio.transcription;
 
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -121,6 +124,27 @@ class DashScopeAudioTranscriptionOptionsTests {
                 new DashScopeAudioTranscriptionOptions.TranslationOptions("en", "zh");
         assertThat(translationOptions.getSourceLang()).isEqualTo("en");
         assertThat(translationOptions.getTargetLang()).isEqualTo("zh");
+    }
+
+    @Test
+    void testBuilderUsesLocalAbstractBuilder() {
+        Class<?> builderClass = DashScopeAudioTranscriptionOptions.Builder.class;
+
+        assertThat(Modifier.isFinal(builderClass.getModifiers())).isTrue();
+        assertThat(builderClass.getSuperclass().getSimpleName()).isEqualTo("AbstractBuilder");
+        assertThat(builderClass.getGenericSuperclass()).isInstanceOf(ParameterizedType.class);
+
+        Type[] typeArguments = ((ParameterizedType) builderClass.getGenericSuperclass()).getActualTypeArguments();
+        assertThat(typeArguments).containsExactly(DashScopeAudioTranscriptionOptions.class, builderClass);
+    }
+
+    @Test
+    void testBuilderGenericChainingKeepsDashScopeSpecificSetters() {
+        DashScopeAudioTranscriptionOptions.Builder builder = DashScopeAudioTranscriptionOptions.builder()
+                .model("gummy-realtime-v1")
+                .vocabularyId("vocab-1");
+
+        assertThat(builder.build().getVocabularyId()).isEqualTo("vocab-1");
     }
 
     @Test

--- a/models/spring-ai-alibaba-dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/tts/DashScopeAudioSpeechOptionsTests.java
+++ b/models/spring-ai-alibaba-dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/tts/DashScopeAudioSpeechOptionsTests.java
@@ -21,7 +21,10 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.ai.audio.tts.TextToSpeechOptions;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class DashScopeAudioSpeechOptionsTests {
 
@@ -100,20 +103,81 @@ class DashScopeAudioSpeechOptionsTests {
         List<String> languageHints = new ArrayList<>(List.of("zh"));
         DashScopeAudioSpeechOptions original = DashScopeAudioSpeechOptions.builder()
                 .model("sambert-zhichu-v1")
-                .languageHints(new ArrayList<>(languageHints))
+                .languageHints(languageHints)
                 .build();
 
         DashScopeAudioSpeechOptions copy = original.mutate()
                 .voice("longxiaoyun")
                 .build();
         languageHints.add("en");
-        copy.getLanguageHints().add("ja");
 
         assertThat(copy).isNotSameAs(original);
         assertThat(original.getLanguageHints()).containsExactly("zh");
-        assertThat(copy.getLanguageHints()).containsExactly("zh", "ja");
+        assertThat(copy.getLanguageHints()).containsExactly("zh");
         assertThat(original.getVoice()).isEqualTo("longanyang");
         assertThat(copy.getVoice()).isEqualTo("longxiaoyun");
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> copy.getLanguageHints().add("ja"));
+    }
+
+    @Test
+    void testBuilderImplementsSpringAiTextToSpeechOptionsBuilder() {
+        assertThat(DashScopeAudioSpeechOptions.builder()).isInstanceOf(TextToSpeechOptions.Builder.class);
+    }
+
+    @Test
+    void testMergeTextToSpeechOptionsAppliesGenericFieldsOnly() {
+        DashScopeAudioSpeechOptions defaultOptions = DashScopeAudioSpeechOptions.builder()
+                .model("sambert-zhichu-v1")
+                .textType("ssml")
+                .voice("longxiaochun")
+                .format("wav")
+                .sampleRate(24000)
+                .speed(1.0)
+                .build();
+        TextToSpeechOptions requestOptions = TextToSpeechOptions.builder()
+                .model("qwen-tts")
+                .voice("Chelsie")
+                .format("mp3")
+                .speed(1.25)
+                .build();
+
+        DashScopeAudioSpeechOptions merged = DashScopeAudioSpeechOptions.builder()
+                .from(defaultOptions)
+                .merge(requestOptions)
+                .build();
+
+        assertThat(merged.getModel()).isEqualTo("qwen-tts");
+        assertThat(merged.getVoice()).isEqualTo("Chelsie");
+        assertThat(merged.getFormat()).isEqualTo("mp3");
+        assertThat(merged.getSpeed()).isEqualTo(1.25);
+        assertThat(merged.getTextType()).isEqualTo("ssml");
+        assertThat(merged.getSampleRate()).isEqualTo(24000);
+    }
+
+    @Test
+    void testMergeDashScopeOptionsAppliesProviderSpecificFields() {
+        DashScopeAudioSpeechOptions defaultOptions = DashScopeAudioSpeechOptions.builder()
+                .model("sambert-zhichu-v1")
+                .sampleRate(16000)
+                .languageHints(List.of("zh"))
+                .build();
+        DashScopeAudioSpeechOptions requestOptions = DashScopeAudioSpeechOptions.builder()
+                .model("cosyvoice-v1")
+                .sampleRate(24000)
+                .languageHints(List.of("en"))
+                .enableSsml(true)
+                .build();
+
+        DashScopeAudioSpeechOptions merged = DashScopeAudioSpeechOptions.builder()
+                .from(defaultOptions)
+                .merge(requestOptions)
+                .build();
+
+        assertThat(merged.getModel()).isEqualTo("cosyvoice-v1");
+        assertThat(merged.getSampleRate()).isEqualTo(24000);
+        assertThat(merged.getLanguageHints()).containsExactly("en");
+        assertThat(merged.getEnableSsml()).isTrue();
     }
 
 }

--- a/models/spring-ai-alibaba-dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/tts/DashScopeAudioSpeechOptionsTests.java
+++ b/models/spring-ai-alibaba-dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/tts/DashScopeAudioSpeechOptionsTests.java
@@ -18,6 +18,9 @@ package com.alibaba.cloud.ai.dashscope.audio.tts;
 import com.alibaba.cloud.ai.dashscope.audio.AudioCommonType.TextType;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -123,6 +126,27 @@ class DashScopeAudioSpeechOptionsTests {
     @Test
     void testBuilderImplementsSpringAiTextToSpeechOptionsBuilder() {
         assertThat(DashScopeAudioSpeechOptions.builder()).isInstanceOf(TextToSpeechOptions.Builder.class);
+    }
+
+    @Test
+    void testBuilderUsesLocalAbstractBuilder() {
+        Class<?> builderClass = DashScopeAudioSpeechOptions.Builder.class;
+
+        assertThat(Modifier.isFinal(builderClass.getModifiers())).isTrue();
+        assertThat(builderClass.getSuperclass().getSimpleName()).isEqualTo("AbstractBuilder");
+        assertThat(builderClass.getGenericSuperclass()).isInstanceOf(ParameterizedType.class);
+
+        Type[] typeArguments = ((ParameterizedType) builderClass.getGenericSuperclass()).getActualTypeArguments();
+        assertThat(typeArguments).containsExactly(DashScopeAudioSpeechOptions.class, builderClass);
+    }
+
+    @Test
+    void testBuilderGenericChainingKeepsDashScopeSpecificSetters() {
+        DashScopeAudioSpeechOptions.Builder builder = DashScopeAudioSpeechOptions.builder()
+                .model("sambert-zhichu-v1")
+                .sampleRate(24000);
+
+        assertThat(builder.build().getSampleRate()).isEqualTo(24000);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Align DashScope TTS options with the Spring AI 2.0 TextToSpeechOptions builder contract.
- Make DashScope audio option list fields defensive and immutable.
- Update audio options tests for generic merge behavior and provider-specific option merging.

## Test Plan
- mvn -pl models/spring-ai-alibaba-dashscope -DskipITs -Dtest=DashScopeAudioSpeechOptionsTests,DashScopeAudioTranscriptionOptionsTests test
- mvn -pl models/spring-ai-alibaba-dashscope -DskipTests -DskipITs compile