### PR TITLE
feat(dashscope): add REQUIRED tool choice to ToolChoiceBuilder

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
@@ -768,6 +768,11 @@ public class DashScopeApiSpec {
             public static final String NONE = "none";
 
             /**
+             * Model must call at least one function, but it can choose which one.
+             */
+            public static final String REQUIRED = "required";
+
+            /**
              * Specifying a particular function forces the model to call that function.
              */
             public static Object function(String functionName) {

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpecTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpecTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dashscope.spec;
+
+import java.util.Map;
+
+import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionRequestParameter.ToolChoiceBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test cases for {@link ToolChoiceBuilder}.
+ */
+class DashScopeApiSpecTests {
+
+    @Test
+    void autoToolChoice() {
+        assertThat(ToolChoiceBuilder.AUTO).isEqualTo("auto");
+    }
+
+    @Test
+    void noneToolChoice() {
+        assertThat(ToolChoiceBuilder.NONE).isEqualTo("none");
+    }
+
+    @Test
+    void requiredToolChoice() {
+        assertThat(ToolChoiceBuilder.REQUIRED).isEqualTo("required");
+    }
+
+    @Test
+    void functionToolChoice() {
+        assertThat(ToolChoiceBuilder.function("getCurrentWeather"))
+            .isEqualTo(Map.of("type", "function", "function", Map.of("name", "getCurrentWeather")));
+    }
+
+}


### PR DESCRIPTION
## What this PR does

Adds a `REQUIRED` constant to `DashScopeApiSpec.ChatCompletionRequestParameter.ToolChoiceBuilder`, so callers can force the model to invoke at least one tool (while still letting the model choose which one).

Previously `ToolChoiceBuilder` only supported:
- `AUTO` — model decides whether to call a tool
- `NONE` — model will not call a tool
- `function(name)` — force a specific tool

This adds the missing `REQUIRED` ("required") option, aligning DashScope with Spring AI's `ToolChoiceBuilder`.

## Changes
- `DashScopeApiSpec`: add `public static final String REQUIRED = "required";`
- Add `DashScopeApiSpecTests` covering `AUTO` / `NONE` / `REQUIRED` / `function(...)`

## Testing
`mvn -pl models/dashscope test -Dtest=DashScopeApiSpecTests` → 4 passed, BUILD SUCCESS.

Closes [#4702](https://github.com/alibaba/spring-ai-alibaba/issues/4702)