### PR TITLE
fix(dashscope): call qwen-image image models synchronously

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeImageApi.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeImageApi.java
@@ -176,18 +176,6 @@ public class DashScopeImageApi {
 		return new ImageApiPath(this.imagesPath, RequestBodyType.STANDARD);
 	}
 
-	/**
-	 * Check if model only supports async calls.
-	 * Models that only support async will return 403 if async header is not sent.
-	 */
-	private boolean isAsyncOnlyModel(String model) {
-		return model.equals("qwen-image") ||
-			   model.equals("qwen-image-plus") ||
-			   model.equals("qwen-mt-image") ||
-			   model.equals("wanx-v1") ||
-			   model.equals("wanx2.1-imageedit");
-	}
-
 	enum RequestBodyType { STANDARD, IMAGE_GENERATION, OUT_PAINTING }
 
 	private static final class ImageApiPath {

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/image/DashScopeImageModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/image/DashScopeImageModel.java
@@ -317,12 +317,9 @@ public class DashScopeImageModel implements ImageModel {
     /**
      * Check if model only supports async calls.
      * Models that only support async will return 403 if async header is not sent.
-     * This logic must be consistent with DashScopeImageApi.isAsyncOnlyModel().
      */
     private boolean isAsyncOnlyModelForModel(String model) {
-        return "qwen-image".equals(model) ||
-                "qwen-image-plus".equals(model) ||
-                "qwen-mt-image".equals(model) ||
+        return "qwen-mt-image".equals(model) ||
                 "wanx-v1".equals(model) ||
                 "wanx2.1-imageedit".equals(model);
     }
@@ -365,7 +362,8 @@ public class DashScopeImageModel implements ImageModel {
         if (model == null) {
             return false;
         }
-        return model.equals("qwen-image-edit") ||
+        return model.startsWith("qwen-image") ||
+               model.startsWith("z-image") ||
                model.startsWith("wan2.2-t2i") ||
                model.startsWith("wan2.5") ||
                model.startsWith("wan2.6");

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/image/DashScopeImageModelTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/image/DashScopeImageModelTests.java
@@ -19,10 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.alibaba.cloud.ai.dashscope.api.DashScopeImageApi;
 import com.alibaba.cloud.ai.dashscope.image.DashScopeImageModel.Builder;
+import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.InvokeMode;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.DashScopeImageAsyncResponse;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.DashScopeImageAsyncResponse.DashScopeImageAsyncResponseOutput;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.DashScopeImageAsyncResponse.DashScopeImageAsyncResponseResult;
@@ -32,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.image.ImageResponse;
@@ -144,6 +147,44 @@ class DashScopeImageModelTests {
 		assertThatThrownBy(() -> imageModel.call(new ImagePrompt(new ArrayList<>())))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Prompt");
+	}
+
+	@Test
+	void qwenImageDefaultsToSync() {
+		// qwen-image uses the synchronous multimodal-generation endpoint; it must not
+		// send the async header (which would cause HTTP 403). See #228.
+		assertUseAsyncForModel("qwen-image", null, false);
+	}
+
+	@Test
+	void qwenImagePlusDefaultsToSync() {
+		assertUseAsyncForModel("qwen-image-plus", null, false);
+	}
+
+	@Test
+	void qwenImageStaysSyncWhenSyncRequested() {
+		// Explicit SYNC must not be force-upgraded to async for qwen-image.
+		assertUseAsyncForModel("qwen-image", InvokeMode.SYNC, false);
+	}
+
+	@Test
+	void qwenMtImageRemainsAsyncOnly() {
+		// qwen-mt-image is genuinely async-only and stays async even when SYNC is requested.
+		assertUseAsyncForModel("qwen-mt-image", InvokeMode.SYNC, true);
+	}
+
+	private void assertUseAsyncForModel(String model, InvokeMode invokeMode, boolean expectedAsync) {
+		mockSuccessfulImageGeneration();
+
+		DashScopeImageOptions.Builder optionsBuilder = DashScopeImageOptions.builder().model(model).n(1);
+		if (invokeMode != null) {
+			optionsBuilder.invokeMode(invokeMode);
+		}
+		imageModel.call(new ImagePrompt(TEST_PROMPT, optionsBuilder.build()));
+
+		ArgumentCaptor<Boolean> asyncCaptor = ArgumentCaptor.forClass(Boolean.class);
+		verify(dashScopeImageApi).submitImageGenTask(any(), asyncCaptor.capture());
+		assertThat(asyncCaptor.getValue()).isEqualTo(expectedAsync);
 	}
 
 	private void mockSuccessfulImageGeneration() {


### PR DESCRIPTION
## Problem

The whole qwen-image image series (e.g. `qwen-image`, `qwen-image-plus`) fails with:

```
403 - {"code":"AccessDenied","message":"current user api does not support asynchronous calls"}
```

(Closes #228)

## Root cause

In `DashScopeImageModel`, `qwen-image` and `qwen-image-plus` were:
- listed in `isAsyncOnlyModelForModel` (so even an explicit `SYNC` request was force-upgraded to async), and
- absent from `isDefaultSyncModel` (so `AUTO` also defaulted to async),

which means an `X-DashScope-Async=enable` header was always sent. But these models route to the **synchronous** `multimodal-generation/generation` endpoint (`DashScopeImageApi.resolveImagePath`) — the same endpoint `qwen-image-edit` already uses synchronously. That endpoint rejects async calls with HTTP 403, so qwen-image could never generate an image.

## Fix (`DashScopeImageModel`)

- `isDefaultSyncModel`: add `qwen-image*` and `z-image*` so the whole family (incl. `-plus`, `-edit`) defaults to sync, consistent with its endpoint.
- `isAsyncOnlyModelForModel`: remove `qwen-image` / `qwen-image-plus` (keep the genuinely async-only `qwen-mt-image`, `wanx-v1`, `wanx2.1-imageedit`).
- Remove the unused, duplicated `DashScopeImageApi.isAsyncOnlyModel()` — dead code that the "must stay consistent" comment referenced and that helped this drift happen.

## Tests

Added unit tests in `DashScopeImageModelTests` (mock `DashScopeImageApi`, capture the `useAsync` flag with `ArgumentCaptor`, no API key needed):
- `qwen-image` / `qwen-image-plus` → sync under `AUTO`;
- `qwen-image` stays sync under explicit `SYNC`;
- `qwen-mt-image` remains async-only.

`mvn -pl models/dashscope test -Dtest=DashScopeImageModelTests` → 15 passed; `spotless:apply` clean.

> Note: I can't reproduce the live call without a DashScope API key, so correctness rests on the endpoint being synchronous + consistency with `qwen-image-edit` + the reported 403. A maintainer with credentials can confirm end-to-end.