### PR TITLE
fix(baidusearch): avoid NPE when Baidu returns no result container

### DIFF
--- a/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch/src/main/java/com/alibaba/cloud/ai/toolcalling/baidusearch/BaiduSearchService.java
+++ b/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch/src/main/java/com/alibaba/cloud/ai/toolcalling/baidusearch/BaiduSearchService.java
@@ -81,7 +81,9 @@ public class BaiduSearchService
 			List<SearchResult> results = CommonToolCallUtils.handleResponse(html, this::parseHtml, logger);
 
 			if (CollectionUtils.isEmpty(results)) {
-				return null;
+				// Return an empty response rather than null so callers can safely
+				// call getSearchResult() without a NullPointerException.
+				return new Response(List.of());
 			}
 
 			logger.info("baidu search: {},result number:{}", request.query, results.size());
@@ -92,10 +94,14 @@ public class BaiduSearchService
 		}, logger);
 	}
 
-	private List<SearchResult> parseHtml(String htmlContent) {
+	List<SearchResult> parseHtml(String htmlContent) {
 		try {
 			Document doc = Jsoup.parse(htmlContent);
 			Element contentLeft = doc.selectFirst("div#content_left");
+			if (contentLeft == null) {
+				logger.warn("Baidu response did not contain the expected 'div#content_left' element");
+				return new ArrayList<>();
+			}
 			Elements divContents = contentLeft.children();
 			List<SearchResult> listData = new ArrayList<>();
 

--- a/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch/src/test/java/com/alibaba/cloud/ai/toolcalling/baidusearch/BaiduSearchServiceParseHtmlTests.java
+++ b/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch/src/test/java/com/alibaba/cloud/ai/toolcalling/baidusearch/BaiduSearchServiceParseHtmlTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.baidusearch;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link BaiduSearchService#parseHtml(String)}. These do not hit the
+ * network, so they run without any external configuration.
+ */
+class BaiduSearchServiceParseHtmlTests {
+
+	private final BaiduSearchService service = new BaiduSearchService(null, null, null);
+
+	@Test
+	void parseHtmlReturnsEmptyListWhenContentLeftMissing() {
+		// Baidu can return an anti-bot/blank page without div#content_left; parsing must
+		// return an empty list instead of throwing a NullPointerException. See #4701.
+		List<BaiduSearchService.SearchResult> results = service
+			.parseHtml("<html><body><div>blocked</div></body></html>");
+
+		assertTrue(results.isEmpty());
+	}
+
+	@Test
+	void parseHtmlExtractsResultContainers() {
+		String html = "<html><body><div id=\"content_left\">"
+				+ "<div class=\"c-container result-op\" mu=\"https://example.com\">" + "<h3>Example Title</h3>"
+				+ "<div class=\"c-abstract\">Example abstract</div>" + "</div></div></body></html>";
+
+		List<BaiduSearchService.SearchResult> results = service.parseHtml(html);
+
+		assertEquals(1, results.size());
+		assertEquals("Example Title", results.get(0).title());
+		assertEquals("Example abstract", results.get(0).abstractText());
+		assertEquals("https://example.com", results.get(0).sourceUrl());
+	}
+
+}


### PR DESCRIPTION
## 问题

配置百度搜索后，当百度返回的页面不含搜索结果容器时会抛出 NPE，导致工具调用失败。(Closes alibaba/spring-ai-alibaba#4701)

## 根因

`BaiduSearchService.parseHtml` 直接对 `doc.selectFirst("div#content_left")` 取 `.children()`，没有判空：

```java
Element contentLeft = doc.selectFirst("div#content_left");
Elements divContents = contentLeft.children(); // contentLeft 为 null 时 NPE
```

当百度返回反爬页/空白页（不含 `div#content_left`）时，`selectFirst` 返回 null → `.children()` 抛 NPE。该异常被 `parseHtml` 捕获后返回 null，`apply` 因结果为空 `return null`，`query` 也返回 null，最终调用方 `query(q).getSearchResult()` 再次 NPE。

## 修改

- `parseHtml`：`div#content_left` 缺失时返回空列表，不再内部 NPE；
- `apply`：无结果时返回空的 `Response`（而非 `null`），使 `getSearchResult()` 始终可安全调用；
- 将 `parseHtml` 改为包级可见，并补充离线单元测试。

## 测试

新增 `BaiduSearchServiceParseHtmlTests`（不联网、无需配置）：
- 缺少 `div#content_left` 的 HTML → 返回空列表，不抛异常；
- 正常结果页 → 正确解析出标题/摘要/链接。

`mvn -pl tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch test -Dtest=BaiduSearchServiceParseHtmlTests` → 2 passed；`spotless:apply` 通过。

> 现有的 `BaiduSearchTest` 已被 `@Disabled`（注释提到直接抓取网页解析成功率不稳定），本次改动正是为这种不稳定响应提供健壮的兜底。