### PR TITLE
fix(dashscope): serialize transcription special_word_filter/diarization_enabled in snake_case

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeAudioTranscriptionOptions.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeAudioTranscriptionOptions.java
@@ -126,10 +126,10 @@ public class DashScopeAudioTranscriptionOptions implements AudioTranscriptionOpt
     @JsonProperty("timestamp_alignment_enabled")
     private Boolean timestampAlignmentEnabled;
 
-    @JsonProperty("specialWordFilter")
+    @JsonProperty("special_word_filter")
     private String specialWordFilter;
 
-    @JsonProperty("diarizationEnabled")
+    @JsonProperty("diarization_enabled")
     private Boolean diarizationEnabled;
 
     @JsonProperty("speaker_count")

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeAudioTranscriptionOptionsTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeAudioTranscriptionOptionsTests.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.dashscope.audio.transcription;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -126,6 +127,23 @@ class DashScopeAudioTranscriptionOptionsTests {
 		translationOptions.setTargetLang("zh");
 		assertThat(translationOptions.getSourceLang()).isEqualTo("en");
 		assertThat(translationOptions.getTargetLang()).isEqualTo("zh");
+	}
+
+	// specialWordFilter / diarizationEnabled must serialize to snake_case so that the
+	// DashScope API recognizes them (see issue #259).
+	@Test
+	void testSnakeCaseSerializationOfSpecialFields() throws Exception {
+		DashScopeAudioTranscriptionOptions options = DashScopeAudioTranscriptionOptions.builder()
+			.specialWordFilter("*")
+			.diarizationEnabled(true)
+			.build();
+
+		String json = new ObjectMapper().writeValueAsString(options);
+
+		assertThat(json).contains("\"special_word_filter\":\"*\"");
+		assertThat(json).contains("\"diarization_enabled\":true");
+		assertThat(json).doesNotContain("specialWordFilter");
+		assertThat(json).doesNotContain("diarizationEnabled");
 	}
 
 }


### PR DESCRIPTION
## 问题

`DashScopeAudioTranscriptionOptions` 中的 `specialWordFilter` 和 `diarizationEnabled` 两个字段使用了 camelCase 的 `@JsonProperty` 值：

```java
@JsonProperty("specialWordFilter")
private String specialWordFilter;

@JsonProperty("diarizationEnabled")
private Boolean diarizationEnabled;
```

而该类其余所有字段以及 DashScope 实际接口参数都使用 snake_case（如 `special_word_filter`、`diarization_enabled`）。因此这两个参数序列化后发往服务端时不会被识别，等于失效。

## 修改

将两处注解改为 snake_case：

```java
@JsonProperty("special_word_filter")
@JsonProperty("diarization_enabled")
```

并新增序列化单测，断言这两个字段输出为 snake_case key（无需 API key）。

## 测试

`mvn -pl models/dashscope test -Dtest=DashScopeAudioTranscriptionOptionsTests` → 4 passed。

Closes #259