### PR TITLE
fix(dashscope): map transcription channel_id/duration/sentences into metadata

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeTranscriptionResponse.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeTranscriptionResponse.java
@@ -74,9 +74,14 @@ public class DashScopeTranscriptionResponse extends AudioTranscriptionResponse {
         private DashScopeAudioTranscriptionMetadata metadata;
 
         @JsonCreator
-        public DashScopeAudioTranscription(@JsonProperty("text") @JsonAlias("transcript") String text) {
+        public DashScopeAudioTranscription(@JsonProperty("text") @JsonAlias("transcript") String text,
+                @JsonProperty("channel_id") Integer channelId,
+                @JsonProperty("content_duration_in_milliseconds") Integer contentDurationInMilliseconds,
+                @JsonProperty("sentences") List<Sentence> sentences) {
             super(text != null ? text : "");
             this.text = text;
+            this.metadata = new DashScopeAudioTranscriptionMetadata(null, null, null, null, null, channelId,
+                    contentDurationInMilliseconds, sentences);
         }
 
         public void setMetadata(DashScopeAudioTranscriptionMetadata metadata) {

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeTranscriptionResponse.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeTranscriptionResponse.java
@@ -73,6 +73,14 @@ public class DashScopeTranscriptionResponse extends AudioTranscriptionResponse {
         @JsonProperty("metadata")
         private DashScopeAudioTranscriptionMetadata metadata;
 
+        // Kept for backward compatibility: this public constructor was part of the
+        // exported API before the Jackson creator below started mapping the extra
+        // top-level response fields. Removing it would break already-compiled clients.
+        public DashScopeAudioTranscription(String text) {
+            super(text != null ? text : "");
+            this.text = text;
+        }
+
         @JsonCreator
         public DashScopeAudioTranscription(@JsonProperty("text") @JsonAlias("transcript") String text,
                 @JsonProperty("channel_id") Integer channelId,

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeTranscriptionResponse.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeTranscriptionResponse.java
@@ -88,8 +88,13 @@ public class DashScopeTranscriptionResponse extends AudioTranscriptionResponse {
                 @JsonProperty("sentences") List<Sentence> sentences) {
             super(text != null ? text : "");
             this.text = text;
-            this.metadata = new DashScopeAudioTranscriptionMetadata(null, null, null, null, null, channelId,
-                    contentDurationInMilliseconds, sentences);
+            // Only attach metadata when the response actually carries at least one of the
+            // mapped top-level fields. A text-only response keeps metadata null to preserve the
+            // prior behavior and to avoid emitting an empty metadata object on re-serialization.
+            if (channelId != null || contentDurationInMilliseconds != null || sentences != null) {
+                this.metadata = new DashScopeAudioTranscriptionMetadata(null, null, null, null, null, channelId,
+                        contentDurationInMilliseconds, sentences);
+            }
         }
 
         public void setMetadata(DashScopeAudioTranscriptionMetadata metadata) {

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeTranscriptionResponseTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeTranscriptionResponseTests.java
@@ -62,4 +62,14 @@ class DashScopeTranscriptionResponseTests {
 		assertThat(transcription.getText()).isEqualTo("aliased text");
 	}
 
+	// The original single-argument constructor must remain available for backward
+	// compatibility with clients compiled against the previous API.
+	@Test
+	void testSingleArgConstructorStillAvailable() {
+		DashScopeAudioTranscription transcription = new DashScopeAudioTranscription("plain text");
+
+		assertThat(transcription.getText()).isEqualTo("plain text");
+		assertThat(transcription.getMetadata()).isNull();
+	}
+
 }

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeTranscriptionResponseTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeTranscriptionResponseTests.java
@@ -50,9 +50,11 @@ class DashScopeTranscriptionResponseTests {
 		assertThat(transcription.getMetadata().sentences().get(0).text()).isEqualTo("hello world");
 	}
 
-	// The "transcript" alias of the text field must still be honored.
+	// The "transcript" alias of the text field must still be honored. A text-only response
+	// (no channel_id / content_duration_in_milliseconds / sentences) must not create an empty
+	// metadata object — getMetadata() stays null, matching the prior behavior.
 	@Test
-	void testDeserializeHonorsTranscriptAlias() throws Exception {
+	void testDeserializeHonorsTranscriptAliasWithoutCreatingEmptyMetadata() throws Exception {
 		String json = """
 				{ "transcript": "aliased text" }
 				""";
@@ -60,6 +62,7 @@ class DashScopeTranscriptionResponseTests {
 		DashScopeAudioTranscription transcription = objectMapper.readValue(json, DashScopeAudioTranscription.class);
 
 		assertThat(transcription.getText()).isEqualTo("aliased text");
+		assertThat(transcription.getMetadata()).isNull();
 	}
 
 	// The original single-argument constructor must remain available for backward

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeTranscriptionResponseTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/audio/transcription/DashScopeTranscriptionResponseTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dashscope.audio.transcription;
+
+import com.alibaba.cloud.ai.dashscope.audio.transcription.DashScopeTranscriptionResponse.DashScopeAudioTranscription;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DashScopeTranscriptionResponseTests {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	// The DashScope response carries channel_id / content_duration_in_milliseconds /
+	// sentences at the top level; these must be mapped into the metadata (see issue #260).
+	@Test
+	void testDeserializeMapsTopLevelFieldsIntoMetadata() throws Exception {
+		String json = """
+				{
+				  "text": "hello world",
+				  "channel_id": 0,
+				  "content_duration_in_milliseconds": 1234,
+				  "sentences": [
+				    { "begin_time": 0, "end_time": 1000, "text": "hello world" }
+				  ]
+				}
+				""";
+
+		DashScopeAudioTranscription transcription = objectMapper.readValue(json, DashScopeAudioTranscription.class);
+
+		assertThat(transcription.getText()).isEqualTo("hello world");
+		assertThat(transcription.getMetadata()).isNotNull();
+		assertThat(transcription.getMetadata().channelId()).isEqualTo(0);
+		assertThat(transcription.getMetadata().contentDurationInMilliseconds()).isEqualTo(1234);
+		assertThat(transcription.getMetadata().sentences()).hasSize(1);
+		assertThat(transcription.getMetadata().sentences().get(0).text()).isEqualTo("hello world");
+	}
+
+	// The "transcript" alias of the text field must still be honored.
+	@Test
+	void testDeserializeHonorsTranscriptAlias() throws Exception {
+		String json = """
+				{ "transcript": "aliased text" }
+				""";
+
+		DashScopeAudioTranscription transcription = objectMapper.readValue(json, DashScopeAudioTranscription.class);
+
+		assertThat(transcription.getText()).isEqualTo("aliased text");
+	}
+
+}


### PR DESCRIPTION
## 问题

`DashScopeTranscriptionResponse.DashScopeAudioTranscription` 的 `@JsonCreator` 只反序列化了 `text` 字段：

```java
@JsonCreator
public DashScopeAudioTranscription(@JsonProperty("text") @JsonAlias("transcript") String text) {
    super(text != null ? text : "");
    this.text = text;
}
```

而 DashScope 接口实际返回中，`channel_id`、`content_duration_in_milliseconds`、`sentences` 都在顶层返回。由于构造器没有接收这些字段，它们在反序列化时被静默丢弃，调用方拿不到声道、时长和分句信息。

## 修改

扩展 `@JsonCreator`，接收上述三个字段并填充到 `DashScopeAudioTranscriptionMetadata`，同时保留 `text` 字段原有的 `transcript` 别名：

```java
@JsonCreator
public DashScopeAudioTranscription(@JsonProperty("text") @JsonAlias("transcript") String text,
        @JsonProperty("channel_id") Integer channelId,
        @JsonProperty("content_duration_in_milliseconds") Integer contentDurationInMilliseconds,
        @JsonProperty("sentences") List<Sentence> sentences) {
    super(text != null ? text : "");
    this.text = text;
    this.metadata = new DashScopeAudioTranscriptionMetadata(null, null, null, null, null,
            channelId, contentDurationInMilliseconds, sentences);
}
```

该构造器仅由 Jackson 经 `@JsonCreator` 调用，仓库内无其它直接调用点。

## 测试

新增 `DashScopeTranscriptionResponseTests`：验证顶层字段映射进 metadata，且 `transcript` 别名仍生效（无需 API key）。

`mvn -pl models/dashscope test -Dtest=DashScopeTranscriptionResponseTests` → 2 passed。

Closes #260