### PR TITLE
Fix DashScope streaming tool call chunk merging

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelper.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelper.java
@@ -125,9 +125,9 @@ public class DashScopeAiStreamFunctionCallingHelper {
         String phase = (current.phase() != null ? current.phase() : previous.phase());
 
 		List<ToolCall> toolCalls = new ArrayList<>();
-		ToolCall lastPreviousTooCall = null;
+		ToolCall lastPreviousToolCall = null;
 		if (previous.toolCalls() != null) {
-			lastPreviousTooCall = previous.toolCalls().get(previous.toolCalls().size() - 1);
+			lastPreviousToolCall = previous.toolCalls().get(previous.toolCalls().size() - 1);
 			if (previous.toolCalls().size() > 1) {
 				toolCalls.addAll(previous.toolCalls().subList(0, previous.toolCalls().size() - 1));
 			}
@@ -137,22 +137,35 @@ public class DashScopeAiStreamFunctionCallingHelper {
 				throw new IllegalStateException("Currently only one tool call is supported per message!");
 			}
 			var currentToolCall = current.toolCalls().iterator().next();
-			if (StringUtils.hasText(currentToolCall.id())) {
-				if (lastPreviousTooCall != null) {
-					toolCalls.add(lastPreviousTooCall);
+			if (isSameStreamingToolCall(lastPreviousToolCall, currentToolCall)) {
+				toolCalls.add(merge(lastPreviousToolCall, currentToolCall));
+			}
+			else {
+				if (lastPreviousToolCall != null) {
+					toolCalls.add(lastPreviousToolCall);
 				}
 				toolCalls.add(currentToolCall);
 			}
-			else {
-				toolCalls.add(merge(lastPreviousTooCall, currentToolCall));
-			}
 		}
 		else {
-			if (lastPreviousTooCall != null) {
-				toolCalls.add(lastPreviousTooCall);
+			if (lastPreviousToolCall != null) {
+				toolCalls.add(lastPreviousToolCall);
 			}
 		}
 		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls, reasoningContent, partial, phase, annotations, status);
+	}
+
+	private boolean isSameStreamingToolCall(ToolCall previous, ToolCall current) {
+		if (previous == null || current == null) {
+			return false;
+		}
+		if (StringUtils.hasText(previous.id()) && StringUtils.hasText(current.id())) {
+			return previous.id().equals(current.id());
+		}
+		if (!StringUtils.hasText(current.id())) {
+			return true;
+		}
+		return previous.index() != null && current.index() != null && previous.index().equals(current.index());
 	}
 
 	private ToolCall merge(ToolCall previous, ToolCall current) {
@@ -160,10 +173,13 @@ public class DashScopeAiStreamFunctionCallingHelper {
         if (previous == null) {
             return current;
 		}
+		if (current == null) {
+			return previous;
+		}
 
         String id = (StringUtils.hasText(current.id()) ? current.id() : previous.id());
 		String type = (StringUtils.hasText(current.type()) ? current.type() : previous.type());
-		Integer index = (current.index() != 0 ? current.index() : previous.index());
+		Integer index = (current.index() != null && current.index() != 0 ? current.index() : previous.index());
 
 
 		ChatCompletionFunction function = merge(previous.function(), current.function());
@@ -173,6 +189,9 @@ public class DashScopeAiStreamFunctionCallingHelper {
 	private ChatCompletionFunction merge(ChatCompletionFunction previous, ChatCompletionFunction current) {
 		if (previous == null) {
 			return current;
+		}
+		if (current == null) {
+			return previous;
 		}
 		String name = (StringUtils.hasText(current.name()) ? current.name() : previous.name());
 		StringBuilder arguments = new StringBuilder();

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelperTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelperTests.java
@@ -93,16 +93,27 @@ public class DashScopeAiStreamFunctionCallingHelperTests {
 		assertEquals("request-1", result.requestId());
 		List<ToolCall> toolCalls = result.output().choices().get(0).message().toolCalls();
 		assertNotNull(toolCalls);
-		// According to DashScopeAiStreamFunctionCallingHelper implementation, it keeps
-		// all tool calls from previous
-		// and adds tool calls from current, so there should be 2 tool calls here
-		assertEquals(2, toolCalls.size());
+		assertEquals(1, toolCalls.size());
 		assertEquals("tool-1", toolCalls.get(0).id());
 		assertEquals("function-1", toolCalls.get(0).function().name());
-		assertEquals("{\"param", toolCalls.get(0).function().arguments());
-		assertEquals("tool-1", toolCalls.get(1).id());
-		assertEquals("function-1", toolCalls.get(1).function().name());
-		assertEquals("\":\"value\"}", toolCalls.get(1).function().arguments());
+		assertEquals("{\"param\":\"value\"}", toolCalls.get(0).function().arguments());
+	}
+
+	@Test
+	void testMergeWithSameToolCallIdAndMissingFunctionName() {
+		ChatCompletionChunk previous = createChunkWithToolCall("request-1", "tool-1", "get_weather", null);
+		ChatCompletionChunk current = createChunkWithToolCall("request-1", "tool-1", null,
+				"{\"location\":\"Beijing\"}", ChatCompletionFinishReason.TOOL_CALLS);
+
+		ChatCompletionChunk result = helperWithIncrementalOutput.merge(previous, current);
+
+		assertNotNull(result);
+		List<ToolCall> toolCalls = result.output().choices().get(0).message().toolCalls();
+		assertNotNull(toolCalls);
+		assertEquals(1, toolCalls.size());
+		assertEquals("tool-1", toolCalls.get(0).id());
+		assertEquals("get_weather", toolCalls.get(0).function().name());
+		assertEquals("{\"location\":\"Beijing\"}", toolCalls.get(0).function().arguments());
 	}
 
 	@Test
@@ -188,8 +199,8 @@ public class DashScopeAiStreamFunctionCallingHelperTests {
 		// Create previous chunk with multiple tool calls
 		ChatCompletionChunk previous = createChunkWithMultipleToolCalls("request-1");
 		// Create current chunk with a single tool call
-		ChatCompletionChunk current = createChunkWithToolCall("request-1", "tool-2", "function-2",
-				"{\"param2\":\"value2\"}");
+		ChatCompletionChunk current = createChunkWithToolCall("request-1", "tool-3", "function-3",
+				"{\"param3\":\"value3\"}");
 
 		ChatCompletionChunk result = helperWithIncrementalOutput.merge(previous, current);
 
@@ -207,9 +218,9 @@ public class DashScopeAiStreamFunctionCallingHelperTests {
 		assertEquals("tool-2", toolCalls.get(1).id());
 		assertEquals("function-2", toolCalls.get(1).function().name());
 		assertEquals("{\"param2\":\"value2\"}", toolCalls.get(1).function().arguments());
-		assertEquals("tool-2", toolCalls.get(2).id());
-		assertEquals("function-2", toolCalls.get(2).function().name());
-		assertEquals("{\"param2\":\"value2\"}", toolCalls.get(2).function().arguments());
+		assertEquals("tool-3", toolCalls.get(2).id());
+		assertEquals("function-3", toolCalls.get(2).function().name());
+		assertEquals("{\"param3\":\"value3\"}", toolCalls.get(2).function().arguments());
 	}
 
 	// Helper method: Create a simple ChatCompletionChunk


### PR DESCRIPTION
### Describe what this PR does / why we need it

DashScope streaming tool calls can send the function name and arguments in separate chunks. When a later arguments chunk carries the same tool call id but no function name, the stream helper treated it as a new tool call. That left one tool call with the name but no arguments, while the arguments-only chunk could be filtered later by validation.

Fixes #83

### Describe how you did it

- Merge streamed tool-call chunks when they belong to the same tool call id.
- Preserve the previous function name and append later argument chunks during merge.
- Keep support for argument chunks without an id, and make tool-call/function merge null-safe.
- Update helper tests to assert a single merged tool call with both name and arguments.

### Describe how to verify it

- MAVEN_OPTS=-Dfile.encoding=UTF-8; mvn -B -ntp -f models/dashscope/pom.xml test

### Special notes for reviews

The validator behavior is unchanged. The fix keeps incomplete arguments-only chunks from reaching validation as separate tool calls by merging them earlier in the streaming helper.