### PR TITLE
docs(dashscope): clarify multiModel endpoint semantics

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
@@ -225,7 +225,7 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
     private Boolean internalToolExecutionEnabled;
 
     /**
-     * Indicates whether the request involves multiple models
+     * Whether to use the DashScope multimodal generation endpoint.
      */
     private @JsonProperty("multi_model") Boolean multiModel;
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

Clarifies that `DashScopeChatOptions.multiModel` selects the DashScope multimodal generation endpoint. The previous wording, "involves multiple models", could be mistaken for model routing or multi-model orchestration.

### Does this pull request fix one issue?

Fixes #268

### Describe how you did it

Updated the `multiModel` Javadoc to describe its endpoint-selection behavior without changing the public API, configuration binding, or runtime logic.

### Describe how to verify it

- `mvn -B -pl models/dashscope -DskipTests compile`
- `git diff --check`

### Special notes for reviews

This is a documentation-only change. The historical `multiModel` name remains unchanged for compatibility.
