### PR TITLE
fix(dashscope): support cache control for assistant and tool messages

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -528,6 +528,12 @@ public class DashScopeChatModel implements ChatModel {
 			}
 			else if (message.getMessageType() == MessageType.ASSISTANT) {
 				var assistantMessage = (AssistantMessage) message;
+				Object content = assistantMessage.getText();
+				Map<String, String> cacheControl = extractCacheControl(message);
+				if (cacheControl != null) {
+					content = List.of(new MediaContent(assistantMessage.getText(), cacheControl));
+				}
+
 				List<ToolCall> toolCalls = null;
 				if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
 					toolCalls = assistantMessage.getToolCalls().stream().map(toolCall -> {
@@ -548,11 +554,12 @@ public class DashScopeChatModel implements ChatModel {
 					}
 				}
 
-				return List.of(new DashScopeApiSpec.ChatCompletionMessage(assistantMessage.getText(),
+				return List.of(new DashScopeApiSpec.ChatCompletionMessage(content,
 						ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls, null, partial, null, null, null));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {
 				ToolResponseMessage toolMessage = (ToolResponseMessage) message;
+				Map<String, String> cacheControl = extractCacheControl(message);
 
 				toolMessage.getResponses().forEach(response -> {
 					Assert.isTrue(response.id() != null, "ToolResponseMessage must have an id");
@@ -561,8 +568,14 @@ public class DashScopeChatModel implements ChatModel {
 
 				return toolMessage.getResponses()
 					.stream()
-					.map(tr -> new ChatCompletionMessage(tr.responseData(), ChatCompletionMessage.Role.TOOL, tr.name(),
-							tr.id(), null, null, null, null, null, null))
+					.map(tr -> {
+						Object content = tr.responseData();
+						if (cacheControl != null) {
+							content = List.of(new MediaContent(tr.responseData(), cacheControl));
+						}
+						return new ChatCompletionMessage(content, ChatCompletionMessage.Role.TOOL, tr.name(), tr.id(),
+								null, null, null, null, null, null);
+					})
 					.toList();
 			}
 			else {

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -88,6 +88,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * {@link ChatModel} implementation for {@literal Alibaba DashScope} backed by
@@ -566,17 +567,16 @@ public class DashScopeChatModel implements ChatModel {
 					Assert.isTrue(response.name() != null, "ToolResponseMessage must have a name");
 				});
 
-				return toolMessage.getResponses()
-					.stream()
-					.map(tr -> {
-						Object content = tr.responseData();
-						if (cacheControl != null) {
-							content = List.of(new MediaContent(tr.responseData(), cacheControl));
-						}
-						return new ChatCompletionMessage(content, ChatCompletionMessage.Role.TOOL, tr.name(), tr.id(),
-								null, null, null, null, null, null);
-					})
-					.toList();
+				List<ToolResponseMessage.ToolResponse> responses = toolMessage.getResponses();
+				return IntStream.range(0, responses.size()).mapToObj(i -> {
+					ToolResponseMessage.ToolResponse tr = responses.get(i);
+					Object content = tr.responseData();
+					if (cacheControl != null && i == responses.size() - 1) {
+						content = List.of(new MediaContent(tr.responseData(), cacheControl));
+					}
+					return new ChatCompletionMessage(content, ChatCompletionMessage.Role.TOOL, tr.name(), tr.id(), null,
+							null, null, null, null, null);
+				}).toList();
 			}
 			else {
 				throw new IllegalArgumentException("Unsupported message type: " + message.getMessageType());

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
@@ -26,6 +26,7 @@ import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionChunk;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionFinishReason;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionMessage;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionMessage.ChatCompletionFunction;
+import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionMessage.MediaContent;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionMessage.ToolCall;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionOutput;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionOutput.Choice;
@@ -44,6 +45,7 @@ import org.mockito.Mockito;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -1142,6 +1144,107 @@ class DashScopeChatModelTests {
     }
 
     @Test
+    void testCreateRequestWithCacheControlInAssistantMessage() {
+        Map<String, Object> cacheControl = Map.of("type", "ephemeral");
+        AssistantMessage assistantMessage = AssistantMessage.builder()
+                .content(TEST_RESPONSE)
+                .properties(Map.of("cache_control", cacheControl))
+                .build();
+        Prompt prompt = new Prompt(List.of(new UserMessage(TEST_PROMPT), assistantMessage), defaultOptions);
+
+        ChatCompletionRequest request = chatModel.createRequest(prompt, false);
+
+        var assistantRequestMessage = request.input().messages().get(1);
+        assertThat(assistantRequestMessage.role()).isEqualTo(ChatCompletionMessage.Role.ASSISTANT);
+        assertThat(assistantRequestMessage.rawContent()).isInstanceOf(List.class);
+
+        @SuppressWarnings("unchecked")
+        List<MediaContent> contentList = (List<MediaContent>) assistantRequestMessage.rawContent();
+
+        assertThat(contentList).hasSize(1);
+        assertThat(contentList.get(0).text()).isEqualTo(TEST_RESPONSE);
+        assertThat(contentList.get(0).cacheControl()).containsEntry("type", "ephemeral");
+    }
+
+    @Test
+    void testCreateRequestWithCacheControlInAssistantMessageKeepsPartial() {
+        Map<String, Object> cacheControl = Map.of("type", "ephemeral");
+        AssistantMessage assistantMessage = AssistantMessage.builder()
+                .content("def fibonacci(n):")
+                .properties(Map.of("cache_control", cacheControl, "partial", true))
+                .build();
+        Prompt prompt = new Prompt(List.of(new UserMessage(TEST_PROMPT), assistantMessage), defaultOptions);
+
+        ChatCompletionRequest request = chatModel.createRequest(prompt, false);
+
+        var assistantRequestMessage = request.input().messages().get(1);
+        assertThat(assistantRequestMessage.partial()).isTrue();
+        assertThat(assistantRequestMessage.rawContent()).isInstanceOf(List.class);
+
+        @SuppressWarnings("unchecked")
+        List<MediaContent> contentList = (List<MediaContent>) assistantRequestMessage.rawContent();
+
+        assertThat(contentList.get(0).text()).isEqualTo("def fibonacci(n):");
+        assertThat(contentList.get(0).cacheControl()).containsEntry("type", "ephemeral");
+    }
+
+    @Test
+    void testCreateRequestWithCacheControlInAssistantMessageKeepsToolCalls() {
+        Map<String, Object> cacheControl = Map.of("type", "ephemeral");
+        AssistantMessage assistantMessage = AssistantMessage.builder()
+                .content("Calling weather tool.")
+                .properties(Map.of("cache_control", cacheControl))
+                .toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "get_weather", "{\"city\":\"HZ\"}")))
+                .build();
+        Prompt prompt = new Prompt(List.of(new UserMessage(TEST_PROMPT), assistantMessage), defaultOptions);
+
+        ChatCompletionRequest request = chatModel.createRequest(prompt, false);
+
+        var assistantRequestMessage = request.input().messages().get(1);
+        assertThat(assistantRequestMessage.toolCalls()).hasSize(1);
+        assertThat(assistantRequestMessage.toolCalls().get(0).id()).isEqualTo("call-1");
+        assertThat(assistantRequestMessage.toolCalls().get(0).function().name()).isEqualTo("get_weather");
+        assertThat(assistantRequestMessage.rawContent()).isInstanceOf(List.class);
+
+        @SuppressWarnings("unchecked")
+        List<MediaContent> contentList = (List<MediaContent>) assistantRequestMessage.rawContent();
+
+        assertThat(contentList.get(0).cacheControl()).containsEntry("type", "ephemeral");
+    }
+
+    @Test
+    void testCreateRequestWithCacheControlInToolResponseMessage() {
+        Map<String, Object> cacheControl = Map.of("type", "ephemeral");
+        ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+                .responses(List.of(
+                        new ToolResponseMessage.ToolResponse("call-1", "get_weather", "{\"city\":\"HZ\"}"),
+                        new ToolResponseMessage.ToolResponse("call-2", "get_time", "{\"timezone\":\"Asia/Shanghai\"}")))
+                .metadata(Map.of("cache_control", cacheControl))
+                .build();
+        Prompt prompt = new Prompt(List.of(toolResponseMessage), defaultOptions);
+
+        ChatCompletionRequest request = chatModel.createRequest(prompt, false);
+
+        assertThat(request.input().messages()).hasSize(2);
+        var firstToolMessage = request.input().messages().get(0);
+        assertThat(firstToolMessage.role()).isEqualTo(ChatCompletionMessage.Role.TOOL);
+        assertThat(firstToolMessage.name()).isEqualTo("get_weather");
+        assertThat(firstToolMessage.toolCallId()).isEqualTo("call-1");
+        assertThat(firstToolMessage.rawContent()).isInstanceOf(List.class);
+
+        @SuppressWarnings("unchecked")
+        List<MediaContent> firstContentList = (List<MediaContent>) firstToolMessage.rawContent();
+
+        assertThat(firstContentList.get(0).text()).isEqualTo("{\"city\":\"HZ\"}");
+        assertThat(firstContentList.get(0).cacheControl()).containsEntry("type", "ephemeral");
+
+        var secondToolMessage = request.input().messages().get(1);
+        assertThat(secondToolMessage.name()).isEqualTo("get_time");
+        assertThat(secondToolMessage.toolCallId()).isEqualTo("call-2");
+        assertThat(secondToolMessage.rawContent()).isInstanceOf(List.class);
+    }
+
+    @Test
     void testCreateRequestWithoutCacheControl() {
         // Test that message without cache_control stays as plain text
         Message message = new UserMessage(TEST_PROMPT);
@@ -1154,6 +1257,26 @@ class DashScopeChatModelTests {
         // Without cache_control, content should remain as plain String
         assertThat(firstMessage.rawContent()).isInstanceOf(String.class);
         assertThat(firstMessage.rawContent()).isEqualTo(TEST_PROMPT);
+    }
+
+    @Test
+    void testCreateRequestWithoutCacheControlInAssistantAndToolMessages() {
+        AssistantMessage assistantMessage = new AssistantMessage(TEST_RESPONSE);
+        ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+                .responses(List.of(new ToolResponseMessage.ToolResponse("call-1", "get_weather", "{\"city\":\"HZ\"}")))
+                .metadata(Map.of())
+                .build();
+        Prompt prompt = new Prompt(List.of(assistantMessage, toolResponseMessage), defaultOptions);
+
+        ChatCompletionRequest request = chatModel.createRequest(prompt, false);
+
+        var assistantRequestMessage = request.input().messages().get(0);
+        assertThat(assistantRequestMessage.rawContent()).isInstanceOf(String.class);
+        assertThat(assistantRequestMessage.rawContent()).isEqualTo(TEST_RESPONSE);
+
+        var toolRequestMessage = request.input().messages().get(1);
+        assertThat(toolRequestMessage.rawContent()).isInstanceOf(String.class);
+        assertThat(toolRequestMessage.rawContent()).isEqualTo("{\"city\":\"HZ\"}");
     }
 
     @Test

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
@@ -1230,18 +1230,19 @@ class DashScopeChatModelTests {
         assertThat(firstToolMessage.role()).isEqualTo(ChatCompletionMessage.Role.TOOL);
         assertThat(firstToolMessage.name()).isEqualTo("get_weather");
         assertThat(firstToolMessage.toolCallId()).isEqualTo("call-1");
-        assertThat(firstToolMessage.rawContent()).isInstanceOf(List.class);
-
-        @SuppressWarnings("unchecked")
-        List<MediaContent> firstContentList = (List<MediaContent>) firstToolMessage.rawContent();
-
-        assertThat(firstContentList.get(0).text()).isEqualTo("{\"city\":\"HZ\"}");
-        assertThat(firstContentList.get(0).cacheControl()).containsEntry("type", "ephemeral");
+        assertThat(firstToolMessage.rawContent()).isInstanceOf(String.class);
+        assertThat(firstToolMessage.rawContent()).isEqualTo("{\"city\":\"HZ\"}");
 
         var secondToolMessage = request.input().messages().get(1);
         assertThat(secondToolMessage.name()).isEqualTo("get_time");
         assertThat(secondToolMessage.toolCallId()).isEqualTo("call-2");
         assertThat(secondToolMessage.rawContent()).isInstanceOf(List.class);
+
+        @SuppressWarnings("unchecked")
+        List<MediaContent> secondContentList = (List<MediaContent>) secondToolMessage.rawContent();
+
+        assertThat(secondContentList.get(0).text()).isEqualTo("{\"timezone\":\"Asia/Shanghai\"}");
+        assertThat(secondContentList.get(0).cacheControl()).containsEntry("type", "ephemeral");
     }
 
     @Test


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR extends DashScope chat request creation to preserve `cache_control` metadata on assistant and tool response messages.

According to the Alibaba Cloud Model Studio context cache documentation, explicit cache markers are supported on four message types in the `messages` array: System Message, User Message, Assistant Message, and Tool Message. The current implementation already supports system/user cache control, but assistant/tool messages are still serialized as plain text. This PR completes the support by wrapping assistant/tool text content as `MediaContent` when `cache_control` is present, while keeping plain string content when it is absent.

Reference: https://help.aliyun.com/zh/model-studio/context-cache

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Added `cache_control` extraction for `AssistantMessage` and `ToolResponseMessage`
- Wrapped assistant/tool text content as `MediaContent` when `cache_control` exists
- Preserved existing assistant message fields such as `partial` and tool calls
- Kept backward-compatible plain string content when `cache_control` is absent
- Added unit tests for assistant/tool cache control and non-cache-control behavior

### Describe how to verify it

```bash
mvn -pl models/dashscope -Dtest=DashScopeChatModelTests test
```

Result: `BUILD SUCCESS`, 42 tests run, 0 failures, 0 errors, 0 skipped.

### Special notes for reviews

No special notes.