### PR TITLE
Improve DashScope auto-configuration properties for Spring AI 2.x

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkAudioSpeechAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkAudioSpeechAutoConfiguration.java
@@ -55,7 +55,7 @@ public class DashScopeSdkAudioSpeechAutoConfiguration {
 			.apiKey(resolved.apiKey())
 			.workspaceId(resolved.workspaceId())
 			.connectionHeaders(resolved.headers())
-			.defaultOptions(audioSpeechProperties.getOptions())
+			.defaultOptions(audioSpeechProperties.toOptions())
 			.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
 			.build();
 	}

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkAudioSpeechProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkAudioSpeechProperties.java
@@ -16,8 +16,11 @@
 
 package com.alibaba.cloud.ai.autoconfigure.dashscope.sdk;
 
+import java.util.Map;
+
 import com.alibaba.cloud.ai.dashscope.sdk.audio.tts.DashScopeSdkAudioSpeechOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -35,6 +38,10 @@ public class DashScopeSdkAudioSpeechProperties extends DashScopeSdkParentPropert
 		.model("sambert-zhichu-v1")
 		.build();
 
+	public DashScopeSdkAudioSpeechOptions toOptions() {
+		return this.options;
+	}
+
 	public boolean isEnabled() {
 		return this.enabled;
 	}
@@ -43,12 +50,110 @@ public class DashScopeSdkAudioSpeechProperties extends DashScopeSdkParentPropert
 		this.enabled = enabled;
 	}
 
+	@DeprecatedConfigurationProperty(replacement = CONFIG_PREFIX)
+	@Deprecated(since = "2.0.0", forRemoval = true)
 	public DashScopeSdkAudioSpeechOptions getOptions() {
 		return this.options;
 	}
 
 	public void setOptions(DashScopeSdkAudioSpeechOptions options) {
 		this.options = options;
+	}
+
+	public String getModel() {
+		return this.options.getModel();
+	}
+
+	public void setModel(String model) {
+		this.options.setModel(model);
+	}
+
+	public String getVoice() {
+		return this.options.getVoice();
+	}
+
+	public void setVoice(String voice) {
+		this.options.setVoice(voice);
+	}
+
+	public String getFormat() {
+		return this.options.getFormat();
+	}
+
+	public void setFormat(String format) {
+		this.options.setFormat(format);
+	}
+
+	public Double getSpeed() {
+		return this.options.getSpeed();
+	}
+
+	public void setSpeed(Double speed) {
+		this.options.setSpeed(speed);
+	}
+
+	public String getTextType() {
+		return this.options.getTextType();
+	}
+
+	public void setTextType(String textType) {
+		this.options.setTextType(textType);
+	}
+
+	public Integer getSampleRate() {
+		return this.options.getSampleRate();
+	}
+
+	public void setSampleRate(Integer sampleRate) {
+		this.options.setSampleRate(sampleRate);
+	}
+
+	public Integer getVolume() {
+		return this.options.getVolume();
+	}
+
+	public void setVolume(Integer volume) {
+		this.options.setVolume(volume);
+	}
+
+	public Float getRate() {
+		return this.options.getRate();
+	}
+
+	public void setRate(Float rate) {
+		this.options.setRate(rate);
+	}
+
+	public Float getPitch() {
+		return this.options.getPitch();
+	}
+
+	public void setPitch(Float pitch) {
+		this.options.setPitch(pitch);
+	}
+
+	public Boolean getWordTimestampEnabled() {
+		return this.options.getWordTimestampEnabled();
+	}
+
+	public void setWordTimestampEnabled(Boolean wordTimestampEnabled) {
+		this.options.setWordTimestampEnabled(wordTimestampEnabled);
+	}
+
+	public Boolean getPhonemeTimestampEnabled() {
+		return this.options.getPhonemeTimestampEnabled();
+	}
+
+	public void setPhonemeTimestampEnabled(Boolean phonemeTimestampEnabled) {
+		this.options.setPhonemeTimestampEnabled(phonemeTimestampEnabled);
+	}
+
+	public Map<String, String> getHttpHeaders() {
+		return this.options.getHttpHeaders();
+	}
+
+	public void setHttpHeaders(Map<String, String> httpHeaders) {
+		this.options.setHttpHeaders(httpHeaders);
 	}
 
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkAudioTranscriptionAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkAudioTranscriptionAutoConfiguration.java
@@ -56,7 +56,7 @@ public class DashScopeSdkAudioTranscriptionAutoConfiguration {
 			.apiKey(resolved.apiKey())
 			.workspaceId(resolved.workspaceId())
 			.connectionHeaders(resolved.headers())
-			.defaultOptions(audioTranscriptionProperties.getOptions())
+			.defaultOptions(audioTranscriptionProperties.toOptions())
 			.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
 			.build();
 	}

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkAudioTranscriptionProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkAudioTranscriptionProperties.java
@@ -16,8 +16,12 @@
 
 package com.alibaba.cloud.ai.autoconfigure.dashscope.sdk;
 
+import java.util.List;
+import java.util.Map;
+
 import com.alibaba.cloud.ai.dashscope.sdk.audio.transcription.DashScopeSdkAudioTranscriptionOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -35,6 +39,10 @@ public class DashScopeSdkAudioTranscriptionProperties extends DashScopeSdkParent
 		.model("paraformer-v2")
 		.build();
 
+	public DashScopeSdkAudioTranscriptionOptions toOptions() {
+		return this.options;
+	}
+
 	public boolean isEnabled() {
 		return this.enabled;
 	}
@@ -43,12 +51,102 @@ public class DashScopeSdkAudioTranscriptionProperties extends DashScopeSdkParent
 		this.enabled = enabled;
 	}
 
+	@DeprecatedConfigurationProperty(replacement = CONFIG_PREFIX)
+	@Deprecated(since = "2.0.0", forRemoval = true)
 	public DashScopeSdkAudioTranscriptionOptions getOptions() {
 		return this.options;
 	}
 
 	public void setOptions(DashScopeSdkAudioTranscriptionOptions options) {
 		this.options = options;
+	}
+
+	public String getModel() {
+		return this.options.getModel();
+	}
+
+	public void setModel(String model) {
+		this.options.setModel(model);
+	}
+
+	public List<String> getFileUrls() {
+		return this.options.getFileUrls();
+	}
+
+	public void setFileUrls(List<String> fileUrls) {
+		this.options.setFileUrls(fileUrls);
+	}
+
+	public String getPhraseId() {
+		return this.options.getPhraseId();
+	}
+
+	public void setPhraseId(String phraseId) {
+		this.options.setPhraseId(phraseId);
+	}
+
+	public List<Integer> getChannelId() {
+		return this.options.getChannelId();
+	}
+
+	public void setChannelId(List<Integer> channelId) {
+		this.options.setChannelId(channelId);
+	}
+
+	public Boolean getDiarizationEnabled() {
+		return this.options.getDiarizationEnabled();
+	}
+
+	public void setDiarizationEnabled(Boolean diarizationEnabled) {
+		this.options.setDiarizationEnabled(diarizationEnabled);
+	}
+
+	public Integer getSpeakerCount() {
+		return this.options.getSpeakerCount();
+	}
+
+	public void setSpeakerCount(Integer speakerCount) {
+		this.options.setSpeakerCount(speakerCount);
+	}
+
+	public Boolean getDisfluencyRemovalEnabled() {
+		return this.options.getDisfluencyRemovalEnabled();
+	}
+
+	public void setDisfluencyRemovalEnabled(Boolean disfluencyRemovalEnabled) {
+		this.options.setDisfluencyRemovalEnabled(disfluencyRemovalEnabled);
+	}
+
+	public Boolean getTimestampAlignmentEnabled() {
+		return this.options.getTimestampAlignmentEnabled();
+	}
+
+	public void setTimestampAlignmentEnabled(Boolean timestampAlignmentEnabled) {
+		this.options.setTimestampAlignmentEnabled(timestampAlignmentEnabled);
+	}
+
+	public String getSpecialWordFilter() {
+		return this.options.getSpecialWordFilter();
+	}
+
+	public void setSpecialWordFilter(String specialWordFilter) {
+		this.options.setSpecialWordFilter(specialWordFilter);
+	}
+
+	public Boolean getAudioEventDetectionEnabled() {
+		return this.options.getAudioEventDetectionEnabled();
+	}
+
+	public void setAudioEventDetectionEnabled(Boolean audioEventDetectionEnabled) {
+		this.options.setAudioEventDetectionEnabled(audioEventDetectionEnabled);
+	}
+
+	public Map<String, String> getHttpHeaders() {
+		return this.options.getHttpHeaders();
+	}
+
+	public void setHttpHeaders(Map<String, String> httpHeaders) {
+		this.options.setHttpHeaders(httpHeaders);
 	}
 
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkChatAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkChatAutoConfiguration.java
@@ -65,7 +65,7 @@ public class DashScopeSdkChatAutoConfiguration {
 			.apiKey(resolved.apiKey())
 			.workspaceId(resolved.workspaceId())
 			.connectionHeaders(resolved.headers())
-			.defaultOptions(chatProperties.getOptions())
+			.defaultOptions(chatProperties.toOptions())
 			.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
 			.toolCallingManager(toolCallingManager)
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkChatProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkChatProperties.java
@@ -16,8 +16,14 @@
 
 package com.alibaba.cloud.ai.autoconfigure.dashscope.sdk;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import com.alibaba.cloud.ai.dashscope.sdk.chat.DashScopeSdkChatOptions;
+import org.springframework.ai.tool.ToolCallback;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -37,6 +43,10 @@ public class DashScopeSdkChatProperties extends DashScopeSdkParentProperties {
 		.model(DEFAULT_DEPLOYMENT_NAME)
 		.build();
 
+	public DashScopeSdkChatOptions toOptions() {
+		return this.options;
+	}
+
 	public boolean isEnabled() {
 		return this.enabled;
 	}
@@ -45,12 +55,158 @@ public class DashScopeSdkChatProperties extends DashScopeSdkParentProperties {
 		this.enabled = enabled;
 	}
 
+	@DeprecatedConfigurationProperty(replacement = CONFIG_PREFIX)
+	@Deprecated(since = "2.0.0", forRemoval = true)
 	public DashScopeSdkChatOptions getOptions() {
 		return this.options;
 	}
 
 	public void setOptions(DashScopeSdkChatOptions options) {
 		this.options = options;
+	}
+
+	public String getModel() {
+		return this.options.getModel();
+	}
+
+	public void setModel(String model) {
+		this.options.setModel(model);
+	}
+
+	public Boolean getStream() {
+		return this.options.getStream();
+	}
+
+	public void setStream(Boolean stream) {
+		this.options.setStream(stream);
+	}
+
+	public Double getTemperature() {
+		return this.options.getTemperature();
+	}
+
+	public void setTemperature(Double temperature) {
+		this.options.setTemperature(temperature);
+	}
+
+	public Integer getSeed() {
+		return this.options.getSeed();
+	}
+
+	public void setSeed(Integer seed) {
+		this.options.setSeed(seed);
+	}
+
+	public Double getTopP() {
+		return this.options.getTopP();
+	}
+
+	public void setTopP(Double topP) {
+		this.options.setTopP(topP);
+	}
+
+	public Integer getTopK() {
+		return this.options.getTopK();
+	}
+
+	public void setTopK(Integer topK) {
+		this.options.setTopK(topK);
+	}
+
+	public List<Object> getStop() {
+		return this.options.getStop();
+	}
+
+	public void setStop(List<Object> stop) {
+		this.options.setStop(stop);
+	}
+
+	public Boolean getEnableSearch() {
+		return this.options.getEnableSearch();
+	}
+
+	public void setEnableSearch(Boolean enableSearch) {
+		this.options.setEnableSearch(enableSearch);
+	}
+
+	public Integer getMaxTokens() {
+		return this.options.getMaxTokens();
+	}
+
+	public void setMaxTokens(Integer maxTokens) {
+		this.options.setMaxTokens(maxTokens);
+	}
+
+	public Boolean getIncrementalOutput() {
+		return this.options.getIncrementalOutput();
+	}
+
+	public void setIncrementalOutput(Boolean incrementalOutput) {
+		this.options.setIncrementalOutput(incrementalOutput);
+	}
+
+	public Double getRepetitionPenalty() {
+		return this.options.getRepetitionPenalty();
+	}
+
+	public void setRepetitionPenalty(Double repetitionPenalty) {
+		this.options.setRepetitionPenalty(repetitionPenalty);
+	}
+
+	public Object getToolChoice() {
+		return this.options.getToolChoice();
+	}
+
+	public void setToolChoice(Object toolChoice) {
+		this.options.setToolChoice(toolChoice);
+	}
+
+	public Map<String, String> getHttpHeaders() {
+		return this.options.getHttpHeaders();
+	}
+
+	public void setHttpHeaders(Map<String, String> httpHeaders) {
+		this.options.setHttpHeaders(httpHeaders);
+	}
+
+	public Map<String, Object> getExtraBody() {
+		return this.options.getExtraBody();
+	}
+
+	public void setExtraBody(Map<String, Object> extraBody) {
+		this.options.setExtraBody(extraBody);
+	}
+
+	public List<ToolCallback> getToolCallbacks() {
+		return this.options.getToolCallbacks();
+	}
+
+	public void setToolCallbacks(List<ToolCallback> toolCallbacks) {
+		this.options.setToolCallbacks(toolCallbacks);
+	}
+
+	public Set<String> getToolNames() {
+		return this.options.getToolNames();
+	}
+
+	public void setToolNames(Set<String> toolNames) {
+		this.options.setToolNames(toolNames);
+	}
+
+	public Boolean getInternalToolExecutionEnabled() {
+		return this.options.getInternalToolExecutionEnabled();
+	}
+
+	public void setInternalToolExecutionEnabled(Boolean internalToolExecutionEnabled) {
+		this.options.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+	}
+
+	public Map<String, Object> getToolContext() {
+		return this.options.getToolContext();
+	}
+
+	public void setToolContext(Map<String, Object> toolContext) {
+		this.options.setToolContext(toolContext);
 	}
 
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkEmbeddingAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkEmbeddingAutoConfiguration.java
@@ -59,7 +59,7 @@ public class DashScopeSdkEmbeddingAutoConfiguration {
 			.apiKey(resolved.apiKey())
 			.workspaceId(resolved.workspaceId())
 			.connectionHeaders(resolved.headers())
-			.defaultOptions(embeddingProperties.getOptions())
+			.defaultOptions(embeddingProperties.toOptions())
 			.metadataMode(embeddingProperties.getMetadataMode())
 			.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkEmbeddingProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkEmbeddingProperties.java
@@ -16,9 +16,12 @@
 
 package com.alibaba.cloud.ai.autoconfigure.dashscope.sdk;
 
+import java.util.Map;
+
 import com.alibaba.cloud.ai.dashscope.sdk.embedding.DashScopeSdkEmbeddingOptions;
 import org.springframework.ai.document.MetadataMode;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -38,6 +41,10 @@ public class DashScopeSdkEmbeddingProperties extends DashScopeSdkParentPropertie
 		.model("text-embedding-v2")
 		.build();
 
+	public DashScopeSdkEmbeddingOptions toOptions() {
+		return this.options;
+	}
+
 	public boolean isEnabled() {
 		return this.enabled;
 	}
@@ -54,12 +61,46 @@ public class DashScopeSdkEmbeddingProperties extends DashScopeSdkParentPropertie
 		this.metadataMode = metadataMode;
 	}
 
+	@DeprecatedConfigurationProperty(replacement = CONFIG_PREFIX)
+	@Deprecated(since = "2.0.0", forRemoval = true)
 	public DashScopeSdkEmbeddingOptions getOptions() {
 		return this.options;
 	}
 
 	public void setOptions(DashScopeSdkEmbeddingOptions options) {
 		this.options = options;
+	}
+
+	public String getModel() {
+		return this.options.getModel();
+	}
+
+	public void setModel(String model) {
+		this.options.setModel(model);
+	}
+
+	public String getTextType() {
+		return this.options.getTextType();
+	}
+
+	public void setTextType(String textType) {
+		this.options.setTextType(textType);
+	}
+
+	public Integer getDimensions() {
+		return this.options.getDimensions();
+	}
+
+	public void setDimensions(Integer dimensions) {
+		this.options.setDimensions(dimensions);
+	}
+
+	public Map<String, String> getHttpHeaders() {
+		return this.options.getHttpHeaders();
+	}
+
+	public void setHttpHeaders(Map<String, String> httpHeaders) {
+		this.options.setHttpHeaders(httpHeaders);
 	}
 
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkImageAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkImageAutoConfiguration.java
@@ -59,7 +59,7 @@ public class DashScopeSdkImageAutoConfiguration {
 			.apiKey(resolved.apiKey())
 			.workspaceId(resolved.workspaceId())
 			.connectionHeaders(resolved.headers())
-			.defaultOptions(imageProperties.getOptions())
+			.defaultOptions(imageProperties.toOptions())
 			.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 			.build();

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkImageProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkImageProperties.java
@@ -16,8 +16,11 @@
 
 package com.alibaba.cloud.ai.autoconfigure.dashscope.sdk;
 
+import java.util.Map;
+
 import com.alibaba.cloud.ai.dashscope.sdk.image.DashScopeSdkImageOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -36,6 +39,10 @@ public class DashScopeSdkImageProperties extends DashScopeSdkParentProperties {
 		.n(1)
 		.build();
 
+	public DashScopeSdkImageOptions toOptions() {
+		return this.options;
+	}
+
 	public boolean isEnabled() {
 		return this.enabled;
 	}
@@ -44,12 +51,126 @@ public class DashScopeSdkImageProperties extends DashScopeSdkParentProperties {
 		this.enabled = enabled;
 	}
 
+	@DeprecatedConfigurationProperty(replacement = CONFIG_PREFIX)
+	@Deprecated(since = "2.0.0", forRemoval = true)
 	public DashScopeSdkImageOptions getOptions() {
 		return this.options;
 	}
 
 	public void setOptions(DashScopeSdkImageOptions options) {
 		this.options = options;
+	}
+
+	public Integer getN() {
+		return this.options.getN();
+	}
+
+	public void setN(Integer n) {
+		this.options.setN(n);
+	}
+
+	public String getModel() {
+		return this.options.getModel();
+	}
+
+	public void setModel(String model) {
+		this.options.setModel(model);
+	}
+
+	public Integer getWidth() {
+		return this.options.getWidth();
+	}
+
+	public void setWidth(Integer width) {
+		this.options.setWidth(width);
+	}
+
+	public Integer getHeight() {
+		return this.options.getHeight();
+	}
+
+	public void setHeight(Integer height) {
+		this.options.setHeight(height);
+	}
+
+	public String getSize() {
+		return this.options.getSize();
+	}
+
+	public void setSize(String size) {
+		this.options.setSize(size);
+	}
+
+	public String getResponseFormat() {
+		return this.options.getResponseFormat();
+	}
+
+	public void setResponseFormat(String responseFormat) {
+		this.options.setResponseFormat(responseFormat);
+	}
+
+	public String getStyle() {
+		return this.options.getStyle();
+	}
+
+	public void setStyle(String style) {
+		this.options.setStyle(style);
+	}
+
+	public Integer getSeed() {
+		return this.options.getSeed();
+	}
+
+	public void setSeed(Integer seed) {
+		this.options.setSeed(seed);
+	}
+
+	public String getNegativePrompt() {
+		return this.options.getNegativePrompt();
+	}
+
+	public void setNegativePrompt(String negativePrompt) {
+		this.options.setNegativePrompt(negativePrompt);
+	}
+
+	public String getRefImage() {
+		return this.options.getRefImage();
+	}
+
+	public void setRefImage(String refImage) {
+		this.options.setRefImage(refImage);
+	}
+
+	public Integer getPollIntervalMs() {
+		return this.options.getPollIntervalMs();
+	}
+
+	public void setPollIntervalMs(Integer pollIntervalMs) {
+		this.options.setPollIntervalMs(pollIntervalMs);
+	}
+
+	public Boolean getAsync() {
+		return this.options.getAsync();
+	}
+
+	public void setAsync(Boolean async) {
+		this.options.setAsync(async);
+	}
+
+	public Map<String, String> getHttpHeaders() {
+		return this.options.getHttpHeaders();
+	}
+
+	public void setHttpHeaders(Map<String, String> httpHeaders) {
+		this.options.setHttpHeaders(httpHeaders);
+	}
+
+	public Map<String, Object> getExtraBody() {
+		return this.options.getExtraBody();
+	}
+
+	public void setExtraBody(Map<String, Object> extraBody) {
+		this.options.setExtraBody(extraBody);
 	}
 
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -7,6 +7,419 @@
       "description": "Enable DashScope SDK model.",
       "sourceType": "com.alibaba.cloud.ai.autoconfigure.dashscope.sdk.DashScopeSdkConnectionProperties",
       "defaultValue": true
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.speech.options.model",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.speech.model"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.speech.options.voice",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.speech.voice"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.speech.options.format",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.speech.format"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.speech.options.speed",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.speech.speed"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.speech.options.text-type",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.speech.text-type"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.speech.options.sample-rate",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.speech.sample-rate"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.speech.options.volume",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.speech.volume"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.speech.options.rate",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.speech.rate"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.speech.options.pitch",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.speech.pitch"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.speech.options.word-timestamp-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.speech.word-timestamp-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.speech.options.phoneme-timestamp-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.speech.phoneme-timestamp-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.speech.options.http-headers",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.speech.http-headers"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.transcription.options.model",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.transcription.model"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.transcription.options.file-urls",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.transcription.file-urls"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.transcription.options.phrase-id",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.transcription.phrase-id"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.transcription.options.channel-id",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.transcription.channel-id"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.transcription.options.diarization-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.transcription.diarization-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.transcription.options.speaker-count",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.transcription.speaker-count"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.transcription.options.disfluency-removal-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.transcription.disfluency-removal-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.transcription.options.timestamp-alignment-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.transcription.timestamp-alignment-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.transcription.options.special-word-filter",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.transcription.special-word-filter"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.transcription.options.audio-event-detection-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.transcription.audio-event-detection-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.audio.transcription.options.http-headers",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.audio.transcription.http-headers"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.model",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.model"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.stream",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.stream"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.temperature",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.temperature"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.seed",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.seed"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.top-p",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.top-p"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.top-k",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.top-k"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.stop",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.stop"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.enable-search",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.enable-search"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.max-tokens",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.max-tokens"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.incremental-output",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.incremental-output"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.repetition-penalty",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.repetition-penalty"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.tool-choice",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.tool-choice"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.http-headers",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.http-headers"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.extra-body",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.extra-body"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.tool-callbacks",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.tool-callbacks"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.tool-names",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.tool-names"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.internal-tool-execution-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.internal-tool-execution-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.chat.options.tool-context",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.chat.tool-context"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.embedding.options.model",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.embedding.model"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.embedding.options.text-type",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.embedding.text-type"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.embedding.options.dimensions",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.embedding.dimensions"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.embedding.options.http-headers",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.embedding.http-headers"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.image.options.n",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.image.n"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.image.options.model",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.image.model"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.image.options.width",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.image.width"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.image.options.height",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.image.height"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.image.options.size",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.image.size"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.image.options.response-format",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.image.response-format"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.image.options.style",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.image.style"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.image.options.seed",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.image.seed"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.image.options.negative-prompt",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.image.negative-prompt"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.image.options.ref-image",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.image.ref-image"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.image.options.poll-interval-ms",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.image.poll-interval-ms"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.image.options.async",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.image.async"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.image.options.http-headers",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.image.http-headers"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.sdk.image.options.extra-body",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.sdk.image.extra-body"
+      }
     }
   ],
   "hints": []

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/test/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkPropertiesTests.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope-sdk/src/test/java/com/alibaba/cloud/ai/autoconfigure/dashscope/sdk/DashScopeSdkPropertiesTests.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.autoconfigure.dashscope.sdk;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DashScopeSdkPropertiesTests {
+
+	@Test
+	void chatPropertiesBindFlatOptions() {
+		DashScopeSdkChatProperties properties = bind(DashScopeSdkChatProperties.CONFIG_PREFIX,
+				DashScopeSdkChatProperties.class,
+				"spring.ai.dashscope.sdk.chat.model", "qwen-sdk-test",
+				"spring.ai.dashscope.sdk.chat.temperature", "0.6",
+				"spring.ai.dashscope.sdk.chat.enable-search", "true");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("qwen-sdk-test");
+		assertThat(properties.toOptions().getTemperature()).isEqualTo(0.6d);
+		assertThat(properties.toOptions().getEnableSearch()).isTrue();
+	}
+
+	@Test
+	void chatPropertiesStillBindLegacyOptions() {
+		DashScopeSdkChatProperties properties = bind(DashScopeSdkChatProperties.CONFIG_PREFIX,
+				DashScopeSdkChatProperties.class,
+				"spring.ai.dashscope.sdk.chat.options.model", "legacy-sdk-qwen");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("legacy-sdk-qwen");
+	}
+
+	@Test
+	void embeddingPropertiesBindFlatOptions() {
+		DashScopeSdkEmbeddingProperties properties = bind(DashScopeSdkEmbeddingProperties.CONFIG_PREFIX,
+				DashScopeSdkEmbeddingProperties.class,
+				"spring.ai.dashscope.sdk.embedding.model", "embedding-sdk-test",
+				"spring.ai.dashscope.sdk.embedding.dimensions", "512",
+				"spring.ai.dashscope.sdk.embedding.text-type", "document");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("embedding-sdk-test");
+		assertThat(properties.toOptions().getDimensions()).isEqualTo(512);
+		assertThat(properties.toOptions().getTextType()).isEqualTo("document");
+	}
+
+	@Test
+	void embeddingPropertiesStillBindLegacyOptions() {
+		DashScopeSdkEmbeddingProperties properties = bind(DashScopeSdkEmbeddingProperties.CONFIG_PREFIX,
+				DashScopeSdkEmbeddingProperties.class,
+				"spring.ai.dashscope.sdk.embedding.options.dimensions", "256");
+
+		assertThat(properties.toOptions().getDimensions()).isEqualTo(256);
+	}
+
+	@Test
+	void imagePropertiesBindFlatOptions() {
+		DashScopeSdkImageProperties properties = bind(DashScopeSdkImageProperties.CONFIG_PREFIX,
+				DashScopeSdkImageProperties.class,
+				"spring.ai.dashscope.sdk.image.model", "wanx-sdk-test",
+				"spring.ai.dashscope.sdk.image.n", "3",
+				"spring.ai.dashscope.sdk.image.size", "1024*1024");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("wanx-sdk-test");
+		assertThat(properties.toOptions().getN()).isEqualTo(3);
+		assertThat(properties.toOptions().getSize()).isEqualTo("1024*1024");
+	}
+
+	@Test
+	void imagePropertiesStillBindLegacyOptions() {
+		DashScopeSdkImageProperties properties = bind(DashScopeSdkImageProperties.CONFIG_PREFIX,
+				DashScopeSdkImageProperties.class,
+				"spring.ai.dashscope.sdk.image.options.negative-prompt", "legacy-negative");
+
+		assertThat(properties.toOptions().getNegativePrompt()).isEqualTo("legacy-negative");
+	}
+
+	@Test
+	void audioSpeechPropertiesBindFlatOptions() {
+		DashScopeSdkAudioSpeechProperties properties = bind(DashScopeSdkAudioSpeechProperties.CONFIG_PREFIX,
+				DashScopeSdkAudioSpeechProperties.class,
+				"spring.ai.dashscope.sdk.audio.speech.model", "sambert-test",
+				"spring.ai.dashscope.sdk.audio.speech.voice", "zhichu",
+				"spring.ai.dashscope.sdk.audio.speech.sample-rate", "16000");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("sambert-test");
+		assertThat(properties.toOptions().getVoice()).isEqualTo("zhichu");
+		assertThat(properties.toOptions().getSampleRate()).isEqualTo(16000);
+	}
+
+	@Test
+	void audioSpeechPropertiesStillBindLegacyOptions() {
+		DashScopeSdkAudioSpeechProperties properties = bind(DashScopeSdkAudioSpeechProperties.CONFIG_PREFIX,
+				DashScopeSdkAudioSpeechProperties.class,
+				"spring.ai.dashscope.sdk.audio.speech.options.voice", "legacy-voice");
+
+		assertThat(properties.toOptions().getVoice()).isEqualTo("legacy-voice");
+	}
+
+	@Test
+	void audioTranscriptionPropertiesBindFlatFileUrls() {
+		DashScopeSdkAudioTranscriptionProperties properties = bind(
+				DashScopeSdkAudioTranscriptionProperties.CONFIG_PREFIX,
+				DashScopeSdkAudioTranscriptionProperties.class,
+				"spring.ai.dashscope.sdk.audio.transcription.model", "paraformer-test",
+				"spring.ai.dashscope.sdk.audio.transcription.file-urls[0]", "https://example.com/audio.wav");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("paraformer-test");
+		assertThat(properties.toOptions().getFileUrls()).containsExactly("https://example.com/audio.wav");
+	}
+
+	@Test
+	void audioTranscriptionPropertiesStillBindLegacyOptions() {
+		DashScopeSdkAudioTranscriptionProperties properties = bind(
+				DashScopeSdkAudioTranscriptionProperties.CONFIG_PREFIX,
+				DashScopeSdkAudioTranscriptionProperties.class,
+				"spring.ai.dashscope.sdk.audio.transcription.options.file-urls[0]",
+				"https://example.com/legacy.wav");
+
+		assertThat(properties.toOptions().getFileUrls()).containsExactly("https://example.com/legacy.wav");
+	}
+
+	@Test
+	void additionalMetadataContainsLegacyOptionsReplacements() throws IOException {
+		String metadata = additionalMetadata();
+
+		assertThat(metadata)
+			.contains("spring.ai.dashscope.sdk.chat.options.model", "spring.ai.dashscope.sdk.chat.model")
+			.contains("spring.ai.dashscope.sdk.image.options.async", "spring.ai.dashscope.sdk.image.async")
+			.contains("spring.ai.dashscope.sdk.audio.transcription.options.file-urls",
+					"spring.ai.dashscope.sdk.audio.transcription.file-urls");
+	}
+
+	private static <T> T bind(String prefix, Class<T> propertiesType, String... pairs) {
+		Map<String, String> source = new LinkedHashMap<>();
+		for (int i = 0; i < pairs.length; i += 2) {
+			source.put(pairs[i], pairs[i + 1]);
+		}
+		return new Binder(new MapConfigurationPropertySource(source)).bind(prefix, propertiesType).get();
+	}
+
+	private static String additionalMetadata() throws IOException {
+		try (var inputStream = DashScopeSdkPropertiesTests.class.getClassLoader()
+			.getResourceAsStream("META-INF/additional-spring-configuration-metadata.json")) {
+			assertThat(inputStream).isNotNull();
+			return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+		}
+	}
+
+}

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAgentAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAgentAutoConfiguration.java
@@ -74,7 +74,7 @@ public class DashScopeAgentAutoConfiguration {
 
         var dashScopeAgent = DashScopeAgent.builder()
                 .dashScopeAgentApi(dashScopeAgentApi)
-                .defaultOptions(agentProperties.getOptions())
+                .defaultOptions(agentProperties.toOptions())
                 .build();
 
         return dashScopeAgent;

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAgentProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAgentProperties.java
@@ -16,9 +16,15 @@
 
 package com.alibaba.cloud.ai.autoconfigure.dashscope;
 
+import java.util.List;
+
+import com.alibaba.cloud.ai.dashscope.agent.DashScopeAgentFlowStreamMode;
 import com.alibaba.cloud.ai.dashscope.agent.DashScopeAgentOptions;
+import com.alibaba.cloud.ai.dashscope.agent.DashScopeAgentRagOptions;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.APPS_COMPLETION_RESTFUL_URL;
@@ -49,6 +55,10 @@ public class DashScopeAgentProperties extends DashScopeParentProperties {
     @NestedConfigurationProperty
     private DashScopeAgentOptions options = DashScopeAgentOptions.builder().build();
 
+    public DashScopeAgentOptions toOptions() {
+        return this.options;
+    }
+
     public boolean isEnabled() {
         return this.enabled;
     }
@@ -65,12 +75,110 @@ public class DashScopeAgentProperties extends DashScopeParentProperties {
         this.agentPath = agentPath;
     }
 
+    @DeprecatedConfigurationProperty(replacement = CONFIG_PREFIX)
+    @Deprecated(since = "2.0.0", forRemoval = true)
     public DashScopeAgentOptions getOptions() {
         return this.options;
     }
 
     public void setOptions(DashScopeAgentOptions options) {
         this.options = options;
+    }
+
+    public String getAppId() {
+        return this.options.getAppId();
+    }
+
+    public void setAppId(String appId) {
+        this.options.setAppId(appId);
+    }
+
+    public String getSessionId() {
+        return this.options.getSessionId();
+    }
+
+    public void setSessionId(String sessionId) {
+        this.options.setSessionId(sessionId);
+    }
+
+    public String getMemoryId() {
+        return this.options.getMemoryId();
+    }
+
+    public void setMemoryId(String memoryId) {
+        this.options.setMemoryId(memoryId);
+    }
+
+    public String getModelId() {
+        return this.options.getModelId();
+    }
+
+    public void setModelId(String modelId) {
+        this.options.setModelId(modelId);
+    }
+
+    public Boolean getIncrementalOutput() {
+        return this.options.getIncrementalOutput();
+    }
+
+    public void setIncrementalOutput(Boolean incrementalOutput) {
+        this.options.setIncrementalOutput(incrementalOutput);
+    }
+
+    public Boolean getHasThoughts() {
+        return this.options.getHasThoughts();
+    }
+
+    public void setHasThoughts(Boolean hasThoughts) {
+        this.options.setHasThoughts(hasThoughts);
+    }
+
+    public Boolean getEnableThinking() {
+        return this.options.getEnableThinking();
+    }
+
+    public void setEnableThinking(Boolean enableThinking) {
+        this.options.setEnableThinking(enableThinking);
+    }
+
+    public List<String> getImages() {
+        return this.options.getImages();
+    }
+
+    public void setImages(List<String> images) {
+        this.options.setImages(images);
+    }
+
+    public List<String> getFiles() {
+        return this.options.getFiles();
+    }
+
+    public void setFiles(List<String> files) {
+        this.options.setFiles(files);
+    }
+
+    public JsonNode getBizParams() {
+        return this.options.getBizParams();
+    }
+
+    public void setBizParams(JsonNode bizParams) {
+        this.options.setBizParams(bizParams);
+    }
+
+    public DashScopeAgentRagOptions getRagOptions() {
+        return this.options.getRagOptions();
+    }
+
+    public void setRagOptions(DashScopeAgentRagOptions ragOptions) {
+        this.options.setRagOptions(ragOptions);
+    }
+
+    public DashScopeAgentFlowStreamMode getFlowStreamMode() {
+        return this.options.getFlowStreamMode();
+    }
+
+    public void setFlowStreamMode(DashScopeAgentFlowStreamMode flowStreamMode) {
+        this.options.setFlowStreamMode(flowStreamMode);
     }
 
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioSpeechAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioSpeechAutoConfiguration.java
@@ -78,7 +78,7 @@ public class DashScopeAudioSpeechAutoConfiguration {
 
 		return DashScopeAudioSpeechModel.builder()
                 .audioSpeechApi(dashScopeAudioSpeechApi)
-                .defaultOptions(audioSpeechProperties.getOptions())
+                .defaultOptions(audioSpeechProperties.toOptions())
                 .retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
                 .build();
 	}

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioSpeechProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioSpeechProperties.java
@@ -16,9 +16,12 @@
 
 package com.alibaba.cloud.ai.autoconfigure.dashscope;
 
+import java.util.List;
+
 import com.alibaba.cloud.ai.dashscope.audio.tts.DashScopeAudioSpeechOptions;
 import com.alibaba.cloud.ai.dashscope.common.DashScopeAudioApiConstants;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -38,12 +41,190 @@ public class DashScopeAudioSpeechProperties extends DashScopeParentProperties {
     @NestedConfigurationProperty
 	private DashScopeAudioSpeechOptions options = DashScopeAudioSpeechOptions.builder().build();
 
+	public DashScopeAudioSpeechOptions toOptions() {
+		return this.options;
+	}
+
+	@DeprecatedConfigurationProperty(replacement = CONFIG_PREFIX)
+	@Deprecated(since = "2.0.0", forRemoval = true)
 	public DashScopeAudioSpeechOptions getOptions() {
 		return options;
 	}
 
 	public void setOptions(DashScopeAudioSpeechOptions options) {
 		this.options = options;
+	}
+
+	public String getModel() {
+		return this.options.getModel();
+	}
+
+	public void setModel(String model) {
+		this.options.setModel(model);
+	}
+
+	public String getVoice() {
+		return this.options.getVoice();
+	}
+
+	public void setVoice(String voice) {
+		this.options.setVoice(voice);
+	}
+
+	public String getTextType() {
+		return this.options.getTextType();
+	}
+
+	public void setTextType(String textType) {
+		this.options.setTextType(textType);
+	}
+
+	public Boolean getEnableAigcTag() {
+		return this.options.getEnableAigcTag();
+	}
+
+	public void setEnableAigcTag(Boolean enableAigcTag) {
+		this.options.setEnableAigcTag(enableAigcTag);
+	}
+
+	public String getAigcPropagator() {
+		return this.options.getAigcPropagator();
+	}
+
+	public void setAigcPropagator(String aigcPropagator) {
+		this.options.setAigcPropagator(aigcPropagator);
+	}
+
+	public String getAigcPropagateId() {
+		return this.options.getAigcPropagateId();
+	}
+
+	public void setAigcPropagateId(String aigcPropagateId) {
+		this.options.setAigcPropagateId(aigcPropagateId);
+	}
+
+	public Integer getSampleRate() {
+		return this.options.getSampleRate();
+	}
+
+	public void setSampleRate(Integer sampleRate) {
+		this.options.setSampleRate(sampleRate);
+	}
+
+	public String getFormat() {
+		return this.options.getFormat();
+	}
+
+	public void setFormat(String format) {
+		this.options.setFormat(format);
+	}
+
+	public void setResponseFormat(String format) {
+		this.options.setResponseFormat(format);
+	}
+
+	public Boolean getWordTimestampEnabled() {
+		return this.options.getWordTimestampEnabled();
+	}
+
+	public void setWordTimestampEnabled(Boolean wordTimestampEnabled) {
+		this.options.setWordTimestampEnabled(wordTimestampEnabled);
+	}
+
+	public Boolean getPhonemeTimestampEnabled() {
+		return this.options.getPhonemeTimestampEnabled();
+	}
+
+	public void setPhonemeTimestampEnabled(Boolean phonemeTimestampEnabled) {
+		this.options.setPhonemeTimestampEnabled(phonemeTimestampEnabled);
+	}
+
+	public Integer getVolume() {
+		return this.options.getVolume();
+	}
+
+	public void setVolume(Integer volume) {
+		this.options.setVolume(volume);
+	}
+
+	public Double getSpeed() {
+		return this.options.getSpeed();
+	}
+
+	public void setSpeed(Double speed) {
+		this.options.setSpeed(speed);
+	}
+
+	public Float getRate() {
+		return this.options.getRate();
+	}
+
+	public void setRate(Float rate) {
+		this.options.setRate(rate);
+	}
+
+	public Float getPitch() {
+		return this.options.getPitch();
+	}
+
+	public void setPitch(Float pitch) {
+		this.options.setPitch(pitch);
+	}
+
+	public Boolean getEnableSsml() {
+		return this.options.getEnableSsml();
+	}
+
+	public void setEnableSsml(Boolean enableSsml) {
+		this.options.setEnableSsml(enableSsml);
+	}
+
+	public Integer getBitRate() {
+		return this.options.getBitRate();
+	}
+
+	public void setBitRate(Integer bitRate) {
+		this.options.setBitRate(bitRate);
+	}
+
+	public Integer getSeed() {
+		return this.options.getSeed();
+	}
+
+	public void setSeed(Integer seed) {
+		this.options.setSeed(seed);
+	}
+
+	public List<String> getLanguageHints() {
+		return this.options.getLanguageHints();
+	}
+
+	public void setLanguageHints(List<String> languageHints) {
+		this.options.setLanguageHints(languageHints);
+	}
+
+	public String getInstruction() {
+		return this.options.getInstruction();
+	}
+
+	public void setInstruction(String instruction) {
+		this.options.setInstruction(instruction);
+	}
+
+	public Boolean getOptimizeInstructions() {
+		return this.options.getOptimizeInstructions();
+	}
+
+	public void setOptimizeInstructions(Boolean optimizeInstructions) {
+		this.options.setOptimizeInstructions(optimizeInstructions);
+	}
+
+	public String getLanguageType() {
+		return this.options.getLanguageType();
+	}
+
+	public void setLanguageType(String languageType) {
+		this.options.setLanguageType(languageType);
 	}
 
     public String getWebsocketUrl() {

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioTranscriptionAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioTranscriptionAutoConfiguration.java
@@ -83,7 +83,7 @@ public class DashScopeAudioTranscriptionAutoConfiguration {
 
 		return DashScopeAudioTranscriptionModel.builder()
                 .audioTranscriptionApi(dashScopeAudioTranscriptionApi)
-                .defaultOptions(audioTranscriptionProperties.getOptions())
+                .defaultOptions(audioTranscriptionProperties.toOptions())
                 .retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
                 .build();
 	}

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioTranscriptionProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioTranscriptionProperties.java
@@ -15,9 +15,12 @@
  */
 package com.alibaba.cloud.ai.autoconfigure.dashscope;
 
+import java.util.List;
+
 import com.alibaba.cloud.ai.dashscope.audio.transcription.DashScopeAudioTranscriptionOptions;
 import com.alibaba.cloud.ai.dashscope.common.DashScopeAudioApiConstants;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -37,12 +40,306 @@ public class DashScopeAudioTranscriptionProperties extends DashScopeParentProper
 	@NestedConfigurationProperty
 	private DashScopeAudioTranscriptionOptions options = DashScopeAudioTranscriptionOptions.builder().build();
 
+	public DashScopeAudioTranscriptionOptions toOptions() {
+		return this.options;
+	}
+
+	@DeprecatedConfigurationProperty(replacement = CONFIG_PREFIX)
+	@Deprecated(since = "2.0.0", forRemoval = true)
 	public DashScopeAudioTranscriptionOptions getOptions() {
 		return this.options;
 	}
 
 	public void setOptions(DashScopeAudioTranscriptionOptions options) {
 		this.options = options;
+	}
+
+	public String getModel() {
+		return this.options.getModel();
+	}
+
+	public void setModel(String model) {
+		this.options.setModel(model);
+	}
+
+	public String getVocabularyId() {
+		return this.options.getVocabularyId();
+	}
+
+	public void setVocabularyId(String vocabularyId) {
+		this.options.setVocabularyId(vocabularyId);
+	}
+
+	public String getFormat() {
+		return this.options.getFormat();
+	}
+
+	public void setFormat(String format) {
+		this.options.setFormat(format);
+	}
+
+	public Integer getSampleRate() {
+		return this.options.getSampleRate();
+	}
+
+	public void setSampleRate(Integer sampleRate) {
+		this.options.setSampleRate(sampleRate);
+	}
+
+	public String getSourceLanguage() {
+		return this.options.getSourceLanguage();
+	}
+
+	public void setSourceLanguage(String sourceLanguage) {
+		this.options.setSourceLanguage(sourceLanguage);
+	}
+
+	public Boolean getTranscriptionEnabled() {
+		return this.options.getTranscriptionEnabled();
+	}
+
+	public void setTranscriptionEnabled(Boolean transcriptionEnabled) {
+		this.options.setTranscriptionEnabled(transcriptionEnabled);
+	}
+
+	public Boolean getTranslationEnabled() {
+		return this.options.getTranslationEnabled();
+	}
+
+	public void setTranslationEnabled(Boolean translationEnabled) {
+		this.options.setTranslationEnabled(translationEnabled);
+	}
+
+	public List<String> getTranslationTargetLanguages() {
+		return this.options.getTranslationTargetLanguages();
+	}
+
+	public void setTranslationTargetLanguages(List<String> translationTargetLanguages) {
+		this.options.setTranslationTargetLanguages(translationTargetLanguages);
+	}
+
+	public DashScopeAudioTranscriptionOptions.AsrOptions getAsrOptions() {
+		return this.options.getAsrOptions();
+	}
+
+	public void setAsrOptions(DashScopeAudioTranscriptionOptions.AsrOptions asrOptions) {
+		this.options.setAsrOptions(asrOptions);
+	}
+
+	public Integer getMaxEndSilence() {
+		return this.options.getMaxEndSilence();
+	}
+
+	public void setMaxEndSilence(Integer maxEndSilence) {
+		this.options.setMaxEndSilence(maxEndSilence);
+	}
+
+	public List<String> getModalities() {
+		return this.options.getModalities();
+	}
+
+	public void setModalities(List<String> modalities) {
+		this.options.setModalities(modalities);
+	}
+
+	public DashScopeAudioTranscriptionOptions.Audio getAudio() {
+		return this.options.getAudio();
+	}
+
+	public void setAudio(DashScopeAudioTranscriptionOptions.Audio audio) {
+		this.options.setAudio(audio);
+	}
+
+	public Boolean getStream() {
+		return this.options.getStream();
+	}
+
+	public void setStream(Boolean stream) {
+		this.options.setStream(stream);
+	}
+
+	public DashScopeAudioTranscriptionOptions.StreamOptions getStreamOptions() {
+		return this.options.getStreamOptions();
+	}
+
+	public void setStreamOptions(DashScopeAudioTranscriptionOptions.StreamOptions streamOptions) {
+		this.options.setStreamOptions(streamOptions);
+	}
+
+	public Integer getMaxTokens() {
+		return this.options.getMaxTokens();
+	}
+
+	public void setMaxTokens(Integer maxTokens) {
+		this.options.setMaxTokens(maxTokens);
+	}
+
+	public Integer getSeed() {
+		return this.options.getSeed();
+	}
+
+	public void setSeed(Integer seed) {
+		this.options.setSeed(seed);
+	}
+
+	public Float getTemperature() {
+		return this.options.getTemperature();
+	}
+
+	public void setTemperature(Float temperature) {
+		this.options.setTemperature(temperature);
+	}
+
+	public Float getTopP() {
+		return this.options.getTopP();
+	}
+
+	public void setTopP(Float topP) {
+		this.options.setTopP(topP);
+	}
+
+	public Float getPresencePenalty() {
+		return this.options.getPresencePenalty();
+	}
+
+	public void setPresencePenalty(Float presencePenalty) {
+		this.options.setPresencePenalty(presencePenalty);
+	}
+
+	public Integer getTopK() {
+		return this.options.getTopK();
+	}
+
+	public void setTopK(Integer topK) {
+		this.options.setTopK(topK);
+	}
+
+	public Float getRepetitionPenalty() {
+		return this.options.getRepetitionPenalty();
+	}
+
+	public void setRepetitionPenalty(Float repetitionPenalty) {
+		this.options.setRepetitionPenalty(repetitionPenalty);
+	}
+
+	public DashScopeAudioTranscriptionOptions.TranslationOptions getTranslationOptions() {
+		return this.options.getTranslationOptions();
+	}
+
+	public void setTranslationOptions(DashScopeAudioTranscriptionOptions.TranslationOptions translationOptions) {
+		this.options.setTranslationOptions(translationOptions);
+	}
+
+	public Boolean getDisfluencyRemovalEnabled() {
+		return this.options.getDisfluencyRemovalEnabled();
+	}
+
+	public void setDisfluencyRemovalEnabled(Boolean disfluencyRemovalEnabled) {
+		this.options.setDisfluencyRemovalEnabled(disfluencyRemovalEnabled);
+	}
+
+	public List<String> getLanguageHints() {
+		return this.options.getLanguageHints();
+	}
+
+	public void setLanguageHints(List<String> languageHints) {
+		this.options.setLanguageHints(languageHints);
+	}
+
+	public Boolean getSemanticPunctuationEnabled() {
+		return this.options.getSemanticPunctuationEnabled();
+	}
+
+	public void setSemanticPunctuationEnabled(Boolean semanticPunctuationEnabled) {
+		this.options.setSemanticPunctuationEnabled(semanticPunctuationEnabled);
+	}
+
+	public Integer getMaxSentenceSilence() {
+		return this.options.getMaxSentenceSilence();
+	}
+
+	public void setMaxSentenceSilence(Integer maxSentenceSilence) {
+		this.options.setMaxSentenceSilence(maxSentenceSilence);
+	}
+
+	public Boolean getMultiThresholdModeEnabled() {
+		return this.options.getMultiThresholdModeEnabled();
+	}
+
+	public void setMultiThresholdModeEnabled(Boolean multiThresholdModeEnabled) {
+		this.options.setMultiThresholdModeEnabled(multiThresholdModeEnabled);
+	}
+
+	public Boolean getPunctuationPredictionEnabled() {
+		return this.options.getPunctuationPredictionEnabled();
+	}
+
+	public void setPunctuationPredictionEnabled(Boolean punctuationPredictionEnabled) {
+		this.options.setPunctuationPredictionEnabled(punctuationPredictionEnabled);
+	}
+
+	public Boolean getHeartbeat() {
+		return this.options.getHeartbeat();
+	}
+
+	public void setHeartbeat(Boolean heartbeat) {
+		this.options.setHeartbeat(heartbeat);
+	}
+
+	public Boolean getInverseTextNormalizationEnabled() {
+		return this.options.getInverseTextNormalizationEnabled();
+	}
+
+	public void setInverseTextNormalizationEnabled(Boolean inverseTextNormalizationEnabled) {
+		this.options.setInverseTextNormalizationEnabled(inverseTextNormalizationEnabled);
+	}
+
+	public List<DashScopeAudioTranscriptionOptions.Resource> getResources() {
+		return this.options.getResources();
+	}
+
+	public void setResources(List<DashScopeAudioTranscriptionOptions.Resource> resources) {
+		this.options.setResources(resources);
+	}
+
+	public Boolean getTimestampAlignmentEnabled() {
+		return this.options.getTimestampAlignmentEnabled();
+	}
+
+	public void setTimestampAlignmentEnabled(Boolean timestampAlignmentEnabled) {
+		this.options.setTimestampAlignmentEnabled(timestampAlignmentEnabled);
+	}
+
+	public String getSpecialWordFilter() {
+		return this.options.getSpecialWordFilter();
+	}
+
+	public void setSpecialWordFilter(String specialWordFilter) {
+		this.options.setSpecialWordFilter(specialWordFilter);
+	}
+
+	public Boolean getDiarizationEnabled() {
+		return this.options.getDiarizationEnabled();
+	}
+
+	public void setDiarizationEnabled(Boolean diarizationEnabled) {
+		this.options.setDiarizationEnabled(diarizationEnabled);
+	}
+
+	public Integer getSpeakerCount() {
+		return this.options.getSpeakerCount();
+	}
+
+	public void setSpeakerCount(Integer speakerCount) {
+		this.options.setSpeakerCount(speakerCount);
+	}
+
+	public List<Integer> getChannelId() {
+		return this.options.getChannelId();
+	}
+
+	public void setChannelId(List<Integer> channelId) {
+		this.options.setChannelId(channelId);
 	}
 
     public String getWebsocketUrl() {

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatAutoConfiguration.java
@@ -91,7 +91,7 @@ public class DashScopeChatAutoConfiguration {
 					.dashScopeApi(dashscopeApi)
 					.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
 					.toolCallingManager(toolCallingManager)
-					.defaultOptions(chatProperties.getOptions())
+					.defaultOptions(chatProperties.toOptions())
 					.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 					.toolExecutionEligibilityPredicate(
 							dashscopeToolExecutionEligibilityPredicate.getIfUnique(DefaultToolExecutionEligibilityPredicate::new))

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatProperties.java
@@ -15,9 +15,17 @@
  */
 package com.alibaba.cloud.ai.autoconfigure.dashscope;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.alibaba.cloud.ai.dashscope.api.DashScopeResponseFormat;
 import com.alibaba.cloud.ai.dashscope.chat.DashScopeChatOptions;
 import com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants;
+import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec;
+import org.springframework.ai.tool.ToolCallback;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -54,12 +62,322 @@ public class DashScopeChatProperties extends DashScopeParentProperties {
 		.model(DEFAULT_DEPLOYMENT_NAME)
 		.build();
 
+	public DashScopeChatOptions toOptions() {
+		return this.options;
+	}
+
+	@DeprecatedConfigurationProperty(replacement = CONFIG_PREFIX)
+	@Deprecated(since = "2.0.0", forRemoval = true)
 	public DashScopeChatOptions getOptions() {
 		return this.options;
 	}
 
 	public void setOptions(DashScopeChatOptions options) {
 		this.options = options;
+	}
+
+	public DashScopeApiSpec.TranslationOptions getTranslationOptions() {
+		return this.options.getTranslationOptions();
+	}
+
+	public void setTranslationOptions(DashScopeApiSpec.TranslationOptions translationOptions) {
+		this.options.setTranslationOptions(translationOptions);
+	}
+
+	public String getOutputFormat() {
+		return this.options.getOutputFormat();
+	}
+
+	public void setOutputFormat(String outputFormat) {
+		this.options.setOutputFormat(outputFormat);
+	}
+
+	public Integer getTopLogProbs() {
+		return this.options.getTopLogProbs();
+	}
+
+	public void setTopLogProbs(Integer topLogProbs) {
+		this.options.setTopLogProbs(topLogProbs);
+	}
+
+	public Boolean getLogprobs() {
+		return this.options.getLogprobs();
+	}
+
+	public void setLogprobs(Boolean logprobs) {
+		this.options.setLogprobs(logprobs);
+	}
+
+	public DashScopeApiSpec.OCROption getOcrOptions() {
+		return this.options.getOcrOptions();
+	}
+
+	public void setOcrOptions(DashScopeApiSpec.OCROption ocrOptions) {
+		this.options.setOcrOptions(ocrOptions);
+	}
+
+	public Boolean getVlEnableImageHwOutput() {
+		return this.options.getVlEnableImageHwOutput();
+	}
+
+	public void setVlEnableImageHwOutput(Boolean vlEnableImageHwOutput) {
+		this.options.setVlEnableImageHwOutput(vlEnableImageHwOutput);
+	}
+
+	public Object getAudio() {
+		return this.options.getAudio();
+	}
+
+	public void setAudio(Object audio) {
+		this.options.setAudio(audio);
+	}
+
+	public Object getStreamOptions() {
+		return this.options.getStreamOptions();
+	}
+
+	public void setStreamOptions(Object streamOptions) {
+		this.options.setStreamOptions(streamOptions);
+	}
+
+	public Object getAsrOptions() {
+		return this.options.getAsrOptions();
+	}
+
+	public void setAsrOptions(Object asrOptions) {
+		this.options.setAsrOptions(asrOptions);
+	}
+
+	public Integer getMaxInputTokens() {
+		return this.options.getMaxInputTokens();
+	}
+
+	public void setMaxInputTokens(Integer maxInputTokens) {
+		this.options.setMaxInputTokens(maxInputTokens);
+	}
+
+	public List<String> getModalities() {
+		return this.options.getModalities();
+	}
+
+	public void setModalities(List<String> modalities) {
+		this.options.setModalities(modalities);
+	}
+
+	public String getModel() {
+		return this.options.getModel();
+	}
+
+	public void setModel(String model) {
+		this.options.setModel(model);
+	}
+
+	public Integer getMaxTokens() {
+		return this.options.getMaxTokens();
+	}
+
+	public void setMaxTokens(Integer maxTokens) {
+		this.options.setMaxTokens(maxTokens);
+	}
+
+	public Boolean getStream() {
+		return this.options.getStream();
+	}
+
+	public void setStream(Boolean stream) {
+		this.options.setStream(stream);
+	}
+
+	public Double getTemperature() {
+		return this.options.getTemperature();
+	}
+
+	public void setTemperature(Double temperature) {
+		this.options.setTemperature(temperature);
+	}
+
+	public DashScopeApiSpec.SearchOptions getSearchOptions() {
+		return this.options.getSearchOptions();
+	}
+
+	public void setSearchOptions(DashScopeApiSpec.SearchOptions searchOptions) {
+		this.options.setSearchOptions(searchOptions);
+	}
+
+	public Boolean getParallelToolCalls() {
+		return this.options.getParallelToolCalls();
+	}
+
+	public void setParallelToolCalls(Boolean parallelToolCalls) {
+		this.options.setParallelToolCalls(parallelToolCalls);
+	}
+
+	public Map<String, String> getHttpHeaders() {
+		return this.options.getHttpHeaders();
+	}
+
+	public void setHttpHeaders(Map<String, String> httpHeaders) {
+		this.options.setHttpHeaders(httpHeaders);
+	}
+
+	public Double getTopP() {
+		return this.options.getTopP();
+	}
+
+	public void setTopP(Double topP) {
+		this.options.setTopP(topP);
+	}
+
+	public Integer getTopK() {
+		return this.options.getTopK();
+	}
+
+	public void setTopK(Integer topK) {
+		this.options.setTopK(topK);
+	}
+
+	public List<Object> getStop() {
+		return this.options.getStop();
+	}
+
+	public void setStop(List<Object> stop) {
+		this.options.setStop(stop);
+	}
+
+	public DashScopeResponseFormat getResponseFormat() {
+		return this.options.getResponseFormat();
+	}
+
+	public void setResponseFormat(DashScopeResponseFormat responseFormat) {
+		this.options.setResponseFormat(responseFormat);
+	}
+
+	public Integer getThinkingBudget() {
+		return this.options.getThinkingBudget();
+	}
+
+	public void setThinkingBudget(Integer thinkingBudget) {
+		this.options.setThinkingBudget(thinkingBudget);
+	}
+
+	public Boolean getEnableCodeInterpreter() {
+		return this.options.getEnableCodeInterpreter();
+	}
+
+	public void setEnableCodeInterpreter(Boolean enableCodeInterpreter) {
+		this.options.setEnableCodeInterpreter(enableCodeInterpreter);
+	}
+
+	public Boolean getEnableSearch() {
+		return this.options.getEnableSearch();
+	}
+
+	public void setEnableSearch(Boolean enableSearch) {
+		this.options.setEnableSearch(enableSearch);
+	}
+
+	public Double getRepetitionPenalty() {
+		return this.options.getRepetitionPenalty();
+	}
+
+	public void setRepetitionPenalty(Double repetitionPenalty) {
+		this.options.setRepetitionPenalty(repetitionPenalty);
+	}
+
+	public List<DashScopeApiSpec.FunctionTool> getTools() {
+		return this.options.getTools();
+	}
+
+	public void setTools(List<DashScopeApiSpec.FunctionTool> tools) {
+		this.options.setTools(tools);
+	}
+
+	public Object getToolChoice() {
+		return this.options.getToolChoice();
+	}
+
+	public void setToolChoice(Object toolChoice) {
+		this.options.setToolChoice(toolChoice);
+	}
+
+	public Integer getSeed() {
+		return this.options.getSeed();
+	}
+
+	public void setSeed(Integer seed) {
+		this.options.setSeed(seed);
+	}
+
+	public List<ToolCallback> getToolCallbacks() {
+		return this.options.getToolCallbacks();
+	}
+
+	public void setToolCallbacks(List<ToolCallback> toolCallbacks) {
+		this.options.setToolCallbacks(toolCallbacks);
+	}
+
+	public Set<String> getToolNames() {
+		return this.options.getToolNames();
+	}
+
+	public void setToolNames(Set<String> toolNames) {
+		this.options.setToolNames(toolNames);
+	}
+
+	public Boolean getInternalToolExecutionEnabled() {
+		return this.options.getInternalToolExecutionEnabled();
+	}
+
+	public void setInternalToolExecutionEnabled(Boolean internalToolExecutionEnabled) {
+		this.options.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+	}
+
+	public Map<String, Object> getToolContext() {
+		return this.options.getToolContext();
+	}
+
+	public void setToolContext(Map<String, Object> toolContext) {
+		this.options.setToolContext(toolContext);
+	}
+
+	public Boolean getIncrementalOutput() {
+		return this.options.getIncrementalOutput();
+	}
+
+	public void setIncrementalOutput(Boolean incrementalOutput) {
+		this.options.setIncrementalOutput(incrementalOutput);
+	}
+
+	public Boolean getVlHighResolutionImages() {
+		return this.options.getVlHighResolutionImages();
+	}
+
+	public void setVlHighResolutionImages(Boolean vlHighResolutionImages) {
+		this.options.setVlHighResolutionImages(vlHighResolutionImages);
+	}
+
+	public Boolean getEnableThinking() {
+		return this.options.getEnableThinking();
+	}
+
+	public void setEnableThinking(Boolean enableThinking) {
+		this.options.setEnableThinking(enableThinking);
+	}
+
+	public Boolean getMultiModel() {
+		return this.options.getMultiModel();
+	}
+
+	public void setMultiModel(Boolean multiModel) {
+		this.options.setMultiModel(multiModel);
+	}
+
+	public Map<String, Object> getExtraBody() {
+		return this.options.getExtraBody();
+	}
+
+	public void setExtraBody(Map<String, Object> extraBody) {
+		this.options.setExtraBody(extraBody);
 	}
 
 	public String getCompletionsPath() {

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeEmbeddingAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeEmbeddingAutoConfiguration.java
@@ -77,7 +77,7 @@ public class DashScopeEmbeddingAutoConfiguration {
 		var embeddingModel = DashScopeEmbeddingModel.builder()
                 .dashScopeApi(dashScopeApi)
                 .metadataMode(embeddingProperties.getMetadataMode())
-                .defaultOptions(embeddingProperties.getOptions())
+                .defaultOptions(embeddingProperties.toOptions())
                 .retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
                 .observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
                 .build();

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeEmbeddingProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeEmbeddingProperties.java
@@ -20,6 +20,7 @@ import com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants;
 import com.alibaba.cloud.ai.dashscope.embedding.text.DashScopeEmbeddingOptions;
 import org.springframework.ai.document.MetadataMode;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 @ConfigurationProperties(DashScopeEmbeddingProperties.CONFIG_PREFIX)
@@ -43,12 +44,50 @@ public class DashScopeEmbeddingProperties extends DashScopeParentProperties {
   private DashScopeEmbeddingOptions options =
       DashScopeEmbeddingOptions.builder().model(DEFAULT_EMBEDDING_MODEL).build();
 
+  public DashScopeEmbeddingOptions toOptions() {
+    return this.options;
+  }
+
+  @DeprecatedConfigurationProperty(replacement = CONFIG_PREFIX)
+  @Deprecated(since = "2.0.0", forRemoval = true)
   public DashScopeEmbeddingOptions getOptions() {
     return this.options;
   }
 
   public void setOptions(DashScopeEmbeddingOptions options) {
     this.options = options;
+  }
+
+  public String getModel() {
+    return this.options.getModel();
+  }
+
+  public void setModel(String model) {
+    this.options.setModel(model);
+  }
+
+  public Integer getDimensions() {
+    return this.options.getDimensions();
+  }
+
+  public void setDimensions(Integer dimensions) {
+    this.options.setDimensions(dimensions);
+  }
+
+  public String getTextType() {
+    return this.options.getTextType();
+  }
+
+  public void setTextType(String textType) {
+    this.options.setTextType(textType);
+  }
+
+  public String getOutputType() {
+    return this.options.getOutputType();
+  }
+
+  public void setOutputType(String outputType) {
+    this.options.setOutputType(outputType);
   }
 
   public MetadataMode getMetadataMode() {
@@ -73,5 +112,6 @@ public class DashScopeEmbeddingProperties extends DashScopeParentProperties {
 
   public void setEmbeddingsPath(String embeddingsPath) {
     this.embeddingsPath = embeddingsPath;
+    this.options.setEmbeddingsPath(embeddingsPath);
   }
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeImageAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeImageAutoConfiguration.java
@@ -77,7 +77,7 @@ public class DashScopeImageAutoConfiguration {
 
 		var dashScopeImageModel = DashScopeImageModel.builder()
                 .dashScopeApi(dashScopeImageApi)
-                .defaultOptions(imageProperties.getOptions())
+                .defaultOptions(imageProperties.toOptions())
                 .pollIntervalMs(imageProperties.getPollIntervalMs())
                 .pollTimeoutMs(imageProperties.getPollTimeoutMs())
                 .retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeImageProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeImageProperties.java
@@ -16,10 +16,19 @@
 
 package com.alibaba.cloud.ai.autoconfigure.dashscope;
 
+import java.util.List;
+
 import com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants;
+import com.alibaba.cloud.ai.dashscope.image.DashScopeImageApiSpec.ImageRequest.ColorPaletteItem;
+import com.alibaba.cloud.ai.dashscope.image.DashScopeImageApiSpec.ImageRequest.Element;
+import com.alibaba.cloud.ai.dashscope.image.DashScopeImageApiSpec.ImageRequest.ReferenceEdge;
+import com.alibaba.cloud.ai.dashscope.image.DashScopeImageApiSpec.ImageRequest.Resource;
+import com.alibaba.cloud.ai.dashscope.image.DashScopeImageApiSpec.InvokeMode;
+import com.alibaba.cloud.ai.dashscope.image.DashScopeImageApiSpec.RequestType;
 import com.alibaba.cloud.ai.dashscope.image.DashScopeImageOptions;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeModel;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.lang.Nullable;
 
@@ -103,11 +112,801 @@ public class DashScopeImageProperties extends DashScopeParentProperties {
         this.pollTimeoutMs = pollTimeoutMs;
     }
 
+    public DashScopeImageOptions toOptions() {
+        return this.options;
+    }
+
+    @DeprecatedConfigurationProperty(replacement = CONFIG_PREFIX)
+    @Deprecated(since = "2.0.0", forRemoval = true)
     public DashScopeImageOptions getOptions() {
         return this.options;
     }
 
     public void setOptions(DashScopeImageOptions options) {
         this.options = options;
+    }
+
+    public String getModel() {
+        return this.options.getModel();
+    }
+
+    public void setModel(String model) {
+        this.options.setModel(model);
+    }
+
+    public Integer getN() {
+        return this.options.getN();
+    }
+
+    public void setN(Integer n) {
+        this.options.setN(n);
+    }
+
+    public Integer getWidth() {
+        return this.options.getWidth();
+    }
+
+    public void setWidth(Integer width) {
+        this.options.setWidth(width);
+    }
+
+    public Integer getHeight() {
+        return this.options.getHeight();
+    }
+
+    public void setHeight(Integer height) {
+        this.options.setHeight(height);
+    }
+
+    public String getSize() {
+        return this.options.getSize();
+    }
+
+    public void setSize(String size) {
+        this.options.setSize(size);
+    }
+
+    public String getStyle() {
+        return this.options.getStyle();
+    }
+
+    public void setStyle(String style) {
+        this.options.setStyle(style);
+    }
+
+    public Integer getStyleIndex() {
+        return this.options.getStyleIndex();
+    }
+
+    public void setStyleIndex(Integer styleIndex) {
+        this.options.setStyleIndex(styleIndex);
+    }
+
+    public String getStyleRefUrl() {
+        return this.options.getStyleRefUrl();
+    }
+
+    public void setStyleRefUrl(String styleRefUrl) {
+        this.options.setStyleRefUrl(styleRefUrl);
+    }
+
+    public String getBaseImageUrl() {
+        return this.options.getBaseImageUrl();
+    }
+
+    public void setBaseImageUrl(String baseImageUrl) {
+        this.options.setBaseImageUrl(baseImageUrl);
+    }
+
+    public List<String> getImages() {
+        return this.options.getImages();
+    }
+
+    public void setImages(List<String> images) {
+        this.options.setImages(images);
+    }
+
+    public String getMaskImageUrl() {
+        return this.options.getMaskImageUrl();
+    }
+
+    public void setMaskImageUrl(String maskImageUrl) {
+        this.options.setMaskImageUrl(maskImageUrl);
+    }
+
+    public String getSketchImageUrl() {
+        return this.options.getSketchImageUrl();
+    }
+
+    public void setSketchImageUrl(String sketchImageUrl) {
+        this.options.setSketchImageUrl(sketchImageUrl);
+    }
+
+    public String getTemplateImageUrl() {
+        return this.options.getTemplateImageUrl();
+    }
+
+    public void setTemplateImageUrl(String templateImageUrl) {
+        this.options.setTemplateImageUrl(templateImageUrl);
+    }
+
+    public List<String> getShoeImageUrl() {
+        return this.options.getShoeImageUrl();
+    }
+
+    public void setShoeImageUrl(List<String> shoeImageUrl) {
+        this.options.setShoeImageUrl(shoeImageUrl);
+    }
+
+    public String getFaceImageUrl() {
+        return this.options.getFaceImageUrl();
+    }
+
+    public void setFaceImageUrl(String faceImageUrl) {
+        this.options.setFaceImageUrl(faceImageUrl);
+    }
+
+    public String getBackgroundImageUrl() {
+        return this.options.getBackgroundImageUrl();
+    }
+
+    public void setBackgroundImageUrl(String backgroundImageUrl) {
+        this.options.setBackgroundImageUrl(backgroundImageUrl);
+    }
+
+    public String getForegroundUrl() {
+        return this.options.getForegroundUrl();
+    }
+
+    public void setForegroundUrl(String foregroundUrl) {
+        this.options.setForegroundUrl(foregroundUrl);
+    }
+
+    public String getPersonImageUrl() {
+        return this.options.getPersonImageUrl();
+    }
+
+    public void setPersonImageUrl(String personImageUrl) {
+        this.options.setPersonImageUrl(personImageUrl);
+    }
+
+    public String getTopGarmentUrl() {
+        return this.options.getTopGarmentUrl();
+    }
+
+    public void setTopGarmentUrl(String topGarmentUrl) {
+        this.options.setTopGarmentUrl(topGarmentUrl);
+    }
+
+    public String getBottomGarmentUrl() {
+        return this.options.getBottomGarmentUrl();
+    }
+
+    public void setBottomGarmentUrl(String bottomGarmentUrl) {
+        this.options.setBottomGarmentUrl(bottomGarmentUrl);
+    }
+
+    public String getCoarseImageUrl() {
+        return this.options.getCoarseImageUrl();
+    }
+
+    public void setCoarseImageUrl(String coarseImageUrl) {
+        this.options.setCoarseImageUrl(coarseImageUrl);
+    }
+
+    public List<String> getUserUrls() {
+        return this.options.getUserUrls();
+    }
+
+    public void setUserUrls(List<String> userUrls) {
+        this.options.setUserUrls(userUrls);
+    }
+
+    public String getRefImg() {
+        return this.options.getRefImg();
+    }
+
+    public void setRefImg(String refImg) {
+        this.options.setRefImg(refImg);
+    }
+
+    public String getPredefinedFaceId() {
+        return this.options.getPredefinedFaceId();
+    }
+
+    public void setPredefinedFaceId(String predefinedFaceId) {
+        this.options.setPredefinedFaceId(predefinedFaceId);
+    }
+
+    public String getFacePrompt() {
+        return this.options.getFacePrompt();
+    }
+
+    public void setFacePrompt(String facePrompt) {
+        this.options.setFacePrompt(facePrompt);
+    }
+
+    public Float getBgstyleScale() {
+        return this.options.getBgstyleScale();
+    }
+
+    public void setBgstyleScale(Float bgstyleScale) {
+        this.options.setBgstyleScale(bgstyleScale);
+    }
+
+    public Boolean getRealPerson() {
+        return this.options.getRealPerson();
+    }
+
+    public void setRealPerson(Boolean realPerson) {
+        this.options.setRealPerson(realPerson);
+    }
+
+    public Integer getSeed() {
+        return this.options.getSeed();
+    }
+
+    public void setSeed(Integer seed) {
+        this.options.setSeed(seed);
+    }
+
+    public Float getRefStrength() {
+        return this.options.getRefStrength();
+    }
+
+    public void setRefStrength(Float refStrength) {
+        this.options.setRefStrength(refStrength);
+    }
+
+    public String getResponseFormat() {
+        return this.options.getResponseFormat();
+    }
+
+    public void setResponseFormat(String responseFormat) {
+        this.options.setResponseFormat(responseFormat);
+    }
+
+    public String getRefMode() {
+        return this.options.getRefMode();
+    }
+
+    public void setRefMode(String refMode) {
+        this.options.setRefMode(refMode);
+    }
+
+    public String getNegativePrompt() {
+        return this.options.getNegativePrompt();
+    }
+
+    public void setNegativePrompt(String negativePrompt) {
+        this.options.setNegativePrompt(negativePrompt);
+    }
+
+    public String getText() {
+        return this.options.getText();
+    }
+
+    public void setText(String text) {
+        this.options.setText(text);
+    }
+
+    public Boolean getPromptExtend() {
+        return this.options.getPromptExtend();
+    }
+
+    public void setPromptExtend(Boolean promptExtend) {
+        this.options.setPromptExtend(promptExtend);
+    }
+
+    public Boolean getWatermark() {
+        return this.options.getWatermark();
+    }
+
+    public void setWatermark(Boolean watermark) {
+        this.options.setWatermark(watermark);
+    }
+
+    public String getFunction() {
+        return this.options.getFunction();
+    }
+
+    public void setFunction(String function) {
+        this.options.setFunction(function);
+    }
+
+    public Integer getSketchWeight() {
+        return this.options.getSketchWeight();
+    }
+
+    public void setSketchWeight(Integer sketchWeight) {
+        this.options.setSketchWeight(sketchWeight);
+    }
+
+    public Boolean getSketchExtraction() {
+        return this.options.getSketchExtraction();
+    }
+
+    public void setSketchExtraction(Boolean sketchExtraction) {
+        this.options.setSketchExtraction(sketchExtraction);
+    }
+
+    public Integer[][] getSketchColor() {
+        return this.options.getSketchColor();
+    }
+
+    public void setSketchColor(Integer[][] sketchColor) {
+        this.options.setSketchColor(sketchColor);
+    }
+
+    public Integer[][] getMaskColor() {
+        return this.options.getMaskColor();
+    }
+
+    public void setMaskColor(Integer[][] maskColor) {
+        this.options.setMaskColor(maskColor);
+    }
+
+    public Integer[][][] getBboxList() {
+        return this.options.getBboxList();
+    }
+
+    public void setBboxList(Integer[][][] bboxList) {
+        this.options.setBboxList(bboxList);
+    }
+
+    public Integer getMaxImages() {
+        return this.options.getMaxImages();
+    }
+
+    public void setMaxImages(Integer maxImages) {
+        this.options.setMaxImages(maxImages);
+    }
+
+    public Boolean getEnableInterleave() {
+        return this.options.getEnableInterleave();
+    }
+
+    public void setEnableInterleave(Boolean enableInterleave) {
+        this.options.setEnableInterleave(enableInterleave);
+    }
+
+    public Boolean getEnableSequential() {
+        return this.options.getEnableSequential();
+    }
+
+    public void setEnableSequential(Boolean enableSequential) {
+        this.options.setEnableSequential(enableSequential);
+    }
+
+    public List<ColorPaletteItem> getColorPalette() {
+        return this.options.getColorPalette();
+    }
+
+    public void setColorPalette(List<ColorPaletteItem> colorPalette) {
+        this.options.setColorPalette(colorPalette);
+    }
+
+    public Boolean getThinkingMode() {
+        return this.options.getThinkingMode();
+    }
+
+    public void setThinkingMode(Boolean thinkingMode) {
+        this.options.setThinkingMode(thinkingMode);
+    }
+
+    public String getOutputRatio() {
+        return this.options.getOutputRatio();
+    }
+
+    public void setOutputRatio(String outputRatio) {
+        this.options.setOutputRatio(outputRatio);
+    }
+
+    public Float getXScale() {
+        return this.options.getXScale();
+    }
+
+    public void setXScale(Float xScale) {
+        this.options.setXScale(xScale);
+    }
+
+    public Float getYScale() {
+        return this.options.getYScale();
+    }
+
+    public void setYScale(Float yScale) {
+        this.options.setYScale(yScale);
+    }
+
+    public Integer getAngle() {
+        return this.options.getAngle();
+    }
+
+    public void setAngle(Integer angle) {
+        this.options.setAngle(angle);
+    }
+
+    public Integer getLeftOffset() {
+        return this.options.getLeftOffset();
+    }
+
+    public void setLeftOffset(Integer leftOffset) {
+        this.options.setLeftOffset(leftOffset);
+    }
+
+    public Integer getRightOffset() {
+        return this.options.getRightOffset();
+    }
+
+    public void setRightOffset(Integer rightOffset) {
+        this.options.setRightOffset(rightOffset);
+    }
+
+    public Integer getTopOffset() {
+        return this.options.getTopOffset();
+    }
+
+    public void setTopOffset(Integer topOffset) {
+        this.options.setTopOffset(topOffset);
+    }
+
+    public Integer getBottomOffset() {
+        return this.options.getBottomOffset();
+    }
+
+    public void setBottomOffset(Integer bottomOffset) {
+        this.options.setBottomOffset(bottomOffset);
+    }
+
+    public Boolean getBestQuality() {
+        return this.options.getBestQuality();
+    }
+
+    public void setBestQuality(Boolean bestQuality) {
+        this.options.setBestQuality(bestQuality);
+    }
+
+    public Boolean getLimitImageSize() {
+        return this.options.getLimitImageSize();
+    }
+
+    public void setLimitImageSize(Boolean limitImageSize) {
+        this.options.setLimitImageSize(limitImageSize);
+    }
+
+    public String getSourceLang() {
+        return this.options.getSourceLang();
+    }
+
+    public void setSourceLang(String sourceLang) {
+        this.options.setSourceLang(sourceLang);
+    }
+
+    public String getTargetLang() {
+        return this.options.getTargetLang();
+    }
+
+    public void setTargetLang(String targetLang) {
+        this.options.setTargetLang(targetLang);
+    }
+
+    public Object getExt() {
+        return this.options.getExt();
+    }
+
+    public void setExt(Object ext) {
+        this.options.setExt(ext);
+    }
+
+    public List<Element> getElementList() {
+        return this.options.getElementList();
+    }
+
+    public void setElementList(List<Element> elementList) {
+        this.options.setElementList(elementList);
+    }
+
+    public String getResultType() {
+        return this.options.getResultType();
+    }
+
+    public void setResultType(String resultType) {
+        this.options.setResultType(resultType);
+    }
+
+    public Integer getSeriesAmount() {
+        return this.options.getSeriesAmount();
+    }
+
+    public void setSeriesAmount(Integer seriesAmount) {
+        this.options.setSeriesAmount(seriesAmount);
+    }
+
+    public String getAspectRatio() {
+        return this.options.getAspectRatio();
+    }
+
+    public void setAspectRatio(String aspectRatio) {
+        this.options.setAspectRatio(aspectRatio);
+    }
+
+    public String getResolution() {
+        return this.options.getResolution();
+    }
+
+    public void setResolution(String resolution) {
+        this.options.setResolution(resolution);
+    }
+
+    public String getShortSideSize() {
+        return this.options.getShortSideSize();
+    }
+
+    public void setShortSideSize(String shortSideSize) {
+        this.options.setShortSideSize(shortSideSize);
+    }
+
+    public Float getScale() {
+        return this.options.getScale();
+    }
+
+    public void setScale(Float scale) {
+        this.options.setScale(scale);
+    }
+
+    public String getModelVersion() {
+        return this.options.getModelVersion();
+    }
+
+    public void setModelVersion(String modelVersion) {
+        this.options.setModelVersion(modelVersion);
+    }
+
+    public Integer getNoiseLevel() {
+        return this.options.getNoiseLevel();
+    }
+
+    public void setNoiseLevel(Integer noiseLevel) {
+        this.options.setNoiseLevel(noiseLevel);
+    }
+
+    public Float getRefPromptWeight() {
+        return this.options.getRefPromptWeight();
+    }
+
+    public void setRefPromptWeight(Float refPromptWeight) {
+        this.options.setRefPromptWeight(refPromptWeight);
+    }
+
+    public ReferenceEdge getReferenceEdge() {
+        return this.options.getReferenceEdge();
+    }
+
+    public void setReferenceEdge(ReferenceEdge referenceEdge) {
+        this.options.setReferenceEdge(referenceEdge);
+    }
+
+    public String getGenerateMode() {
+        return this.options.getGenerateMode();
+    }
+
+    public void setGenerateMode(String generateMode) {
+        this.options.setGenerateMode(generateMode);
+    }
+
+    public String getAuxiliaryParameters() {
+        return this.options.getAuxiliaryParameters();
+    }
+
+    public void setAuxiliaryParameters(String auxiliaryParameters) {
+        this.options.setAuxiliaryParameters(auxiliaryParameters);
+    }
+
+    public String getTitle() {
+        return this.options.getTitle();
+    }
+
+    public void setTitle(String title) {
+        this.options.setTitle(title);
+    }
+
+    public String getSubTitle() {
+        return this.options.getSubTitle();
+    }
+
+    public void setSubTitle(String subTitle) {
+        this.options.setSubTitle(subTitle);
+    }
+
+    public String getBodyText() {
+        return this.options.getBodyText();
+    }
+
+    public void setBodyText(String bodyText) {
+        this.options.setBodyText(bodyText);
+    }
+
+    public String getPromptTextZh() {
+        return this.options.getPromptTextZh();
+    }
+
+    public void setPromptTextZh(String promptTextZh) {
+        this.options.setPromptTextZh(promptTextZh);
+    }
+
+    public String getPromptTextEn() {
+        return this.options.getPromptTextEn();
+    }
+
+    public void setPromptTextEn(String promptTextEn) {
+        this.options.setPromptTextEn(promptTextEn);
+    }
+
+    public String getWhRatios() {
+        return this.options.getWhRatios();
+    }
+
+    public void setWhRatios(String whRatios) {
+        this.options.setWhRatios(whRatios);
+    }
+
+    public String getLoraName() {
+        return this.options.getLoraName();
+    }
+
+    public void setLoraName(String loraName) {
+        this.options.setLoraName(loraName);
+    }
+
+    public Float getLoraWeight() {
+        return this.options.getLoraWeight();
+    }
+
+    public void setLoraWeight(Float loraWeight) {
+        this.options.setLoraWeight(loraWeight);
+    }
+
+    public Float getCtrlRatio() {
+        return this.options.getCtrlRatio();
+    }
+
+    public void setCtrlRatio(Float ctrlRatio) {
+        this.options.setCtrlRatio(ctrlRatio);
+    }
+
+    public Float getCtrlStep() {
+        return this.options.getCtrlStep();
+    }
+
+    public void setCtrlStep(Float ctrlStep) {
+        this.options.setCtrlStep(ctrlStep);
+    }
+
+    public Boolean getCreativeTitleLayout() {
+        return this.options.getCreativeTitleLayout();
+    }
+
+    public void setCreativeTitleLayout(Boolean creativeTitleLayout) {
+        this.options.setCreativeTitleLayout(creativeTitleLayout);
+    }
+
+    public Boolean getFastMode() {
+        return this.options.getFastMode();
+    }
+
+    public void setFastMode(Boolean fastMode) {
+        this.options.setFastMode(fastMode);
+    }
+
+    public Boolean getDilateFlag() {
+        return this.options.getDilateFlag();
+    }
+
+    public void setDilateFlag(Boolean dilateFlag) {
+        this.options.setDilateFlag(dilateFlag);
+    }
+
+    public Boolean getRestoreFace() {
+        return this.options.getRestoreFace();
+    }
+
+    public void setRestoreFace(Boolean restoreFace) {
+        this.options.setRestoreFace(restoreFace);
+    }
+
+    public String getGender() {
+        return this.options.getGender();
+    }
+
+    public void setGender(String gender) {
+        this.options.setGender(gender);
+    }
+
+    public List<String> getClothesType() {
+        return this.options.getClothesType();
+    }
+
+    public void setClothesType(List<String> clothesType) {
+        this.options.setClothesType(clothesType);
+    }
+
+    public List<Resource> getResources() {
+        return this.options.getResources();
+    }
+
+    public void setResources(List<Resource> resources) {
+        this.options.setResources(resources);
+    }
+
+    public Boolean getSkinRetouch() {
+        return this.options.getSkinRetouch();
+    }
+
+    public void setSkinRetouch(Boolean skinRetouch) {
+        this.options.setSkinRetouch(skinRetouch);
+    }
+
+    public Integer getSteps() {
+        return this.options.getSteps();
+    }
+
+    public void setSteps(Integer steps) {
+        this.options.setSteps(steps);
+    }
+
+    public String getFontName() {
+        return this.options.getFontName();
+    }
+
+    public void setFontName(String fontName) {
+        this.options.setFontName(fontName);
+    }
+
+    public String getTtfUrl() {
+        return this.options.getTtfUrl();
+    }
+
+    public void setTtfUrl(String ttfUrl) {
+        this.options.setTtfUrl(ttfUrl);
+    }
+
+    public Integer getImageShortSize() {
+        return this.options.getImageShortSize();
+    }
+
+    public void setImageShortSize(Integer imageShortSize) {
+        this.options.setImageShortSize(imageShortSize);
+    }
+
+    public Boolean getAlphaChannel() {
+        return this.options.getAlphaChannel();
+    }
+
+    public void setAlphaChannel(Boolean alphaChannel) {
+        this.options.setAlphaChannel(alphaChannel);
+    }
+
+    public List<String> getTrainingFileIds() {
+        return this.options.getTrainingFileIds();
+    }
+
+    public void setTrainingFileIds(List<String> trainingFileIds) {
+        this.options.setTrainingFileIds(trainingFileIds);
+    }
+
+    public InvokeMode getInvokeMode() {
+        return this.options.getInvokeMode();
+    }
+
+    public void setInvokeMode(InvokeMode invokeMode) {
+        this.options.setInvokeMode(invokeMode);
+    }
+
+    public RequestType getRequestType() {
+        return this.options.getRequestType();
+    }
+
+    public void setRequestType(RequestType requestType) {
+        this.options.setRequestType(requestType);
     }
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeMultimodalEmbeddingAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeMultimodalEmbeddingAutoConfiguration.java
@@ -74,7 +74,7 @@ public class DashScopeMultimodalEmbeddingAutoConfiguration {
 
 		var embeddingModel = DashScopeMultimodalEmbeddingModel.builder()
 				.dashScopeMultimodalEmbeddingApi(dashScopeApi)
-				.defaultOptions(embeddingProperties.getOptions())
+				.defaultOptions(embeddingProperties.toOptions())
 				.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
 				.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 				.build();

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeMultimodalEmbeddingProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeMultimodalEmbeddingProperties.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.ai.autoconfigure.dashscope;
 import com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants;
 import com.alibaba.cloud.ai.dashscope.embedding.multimodal.DashScopeMultimodalEmbeddingOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -39,12 +40,58 @@ public class DashScopeMultimodalEmbeddingProperties extends DashScopeParentPrope
 			.model(DEFAULT_MULTIMODAL_EMBEDDING_MODEL)
 			.build();
 
+	public DashScopeMultimodalEmbeddingOptions toOptions() {
+		return this.options;
+	}
+
+	@DeprecatedConfigurationProperty(replacement = CONFIG_PREFIX)
+	@Deprecated(since = "2.0.0", forRemoval = true)
 	public DashScopeMultimodalEmbeddingOptions getOptions() {
 		return this.options;
 	}
 
 	public void setOptions(DashScopeMultimodalEmbeddingOptions options) {
 		this.options = options;
+	}
+
+	public String getModel() {
+		return this.options.getModel();
+	}
+
+	public void setModel(String model) {
+		this.options.setModel(model);
+	}
+
+	public Integer getDimensions() {
+		return this.options.getDimensions();
+	}
+
+	public void setDimensions(Integer dimensions) {
+		this.options.setDimensions(dimensions);
+	}
+
+	public String getOutputType() {
+		return this.options.getOutputType();
+	}
+
+	public void setOutputType(String outputType) {
+		this.options.setOutputType(outputType);
+	}
+
+	public Float getFps() {
+		return this.options.getFps();
+	}
+
+	public void setFps(Float fps) {
+		this.options.setFps(fps);
+	}
+
+	public String getInstruct() {
+		return this.options.getInstruct();
+	}
+
+	public void setInstruct(String instruct) {
+		this.options.setInstruct(instruct);
 	}
 
 	public String getMultimodalPath() {

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeRerankAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeRerankAutoConfiguration.java
@@ -79,7 +79,7 @@ public class DashScopeRerankAutoConfiguration {
 
 		return DashScopeRerankModel.builder()
                 .dashScopeApi(dashScopeApi)
-                .defaultOptions(rerankProperties.getOptions())
+                .defaultOptions(rerankProperties.toOptions())
                 .retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
                 .build();
 	}

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeRerankProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeRerankProperties.java
@@ -19,6 +19,7 @@ package com.alibaba.cloud.ai.autoconfigure.dashscope;
 import com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants;
 import com.alibaba.cloud.ai.dashscope.rerank.DashScopeRerankOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -42,37 +43,43 @@ public class DashScopeRerankProperties extends DashScopeParentProperties {
     public static final String DEFAULT_RERANK_MODEL = "gte-rerank";
 
     /**
-     * Top n rerank results.
-     */
-    private Integer topN = 5;
-
-    /**
-     * If need to return original documents.
-     */
-    private Boolean returnDocuments = false;
-
-    /**
      * Default rerank path.
      */
     private String rerankPath = DashScopeApiConstants.TEXT_RERANK_RESTFUL_URL;
 
     @NestedConfigurationProperty
-    private DashScopeRerankOptions options = DashScopeRerankOptions.builder().model(DEFAULT_RERANK_MODEL).build();
+    private DashScopeRerankOptions options = DashScopeRerankOptions.builder()
+            .model(DEFAULT_RERANK_MODEL)
+            .topN(5)
+            .returnDocuments(false)
+            .build();
+
+    public DashScopeRerankOptions toOptions() {
+        return this.options;
+    }
 
     public Integer getTopN() {
-        return topN;
+        return this.options.getTopN();
     }
 
     public void setTopN(Integer topN) {
-        this.topN = topN;
+        this.options.setTopN(topN);
     }
 
     public Boolean getReturnDocuments() {
-        return returnDocuments;
+        return this.options.getReturnDocuments();
     }
 
     public void setReturnDocuments(Boolean returnDocuments) {
-        this.returnDocuments = returnDocuments;
+        this.options.setReturnDocuments(returnDocuments);
+    }
+
+    public String getModel() {
+        return this.options.getModel();
+    }
+
+    public void setModel(String model) {
+        this.options.setModel(model);
     }
 
     public String getRerankPath() {
@@ -83,6 +90,8 @@ public class DashScopeRerankProperties extends DashScopeParentProperties {
         this.rerankPath = rerankPath;
     }
 
+    @DeprecatedConfigurationProperty(replacement = CONFIG_PREFIX)
+    @Deprecated(since = "2.0.0", forRemoval = true)
     public DashScopeRerankOptions getOptions() {
         return options;
     }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeVideoAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeVideoAutoConfiguration.java
@@ -72,7 +72,7 @@ public class DashScopeVideoAutoConfiguration {
 
 		return DashScopeVideoModel.builder()
 			.videoApi(videoApi)
-			.defaultOptions(videoProperties.getOptions())
+			.defaultOptions(videoProperties.toOptions())
 			.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
 			.build();
 	}

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeVideoProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeVideoProperties.java
@@ -19,6 +19,7 @@ import com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants;
 import com.alibaba.cloud.ai.dashscope.common.DashScopeVideoApiConstants;
 import com.alibaba.cloud.ai.dashscope.video.DashScopeVideoOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -41,6 +42,10 @@ public class DashScopeVideoProperties extends DashScopeParentProperties {
 	@NestedConfigurationProperty
     private DashScopeVideoOptions options = DashScopeVideoOptions.builder().build();
 
+    public DashScopeVideoOptions toOptions() {
+        return this.options;
+    }
+
     public String getVideoPath() {
         return videoPath;
     }
@@ -57,12 +62,38 @@ public class DashScopeVideoProperties extends DashScopeParentProperties {
         this.queryTaskPath = queryTaskPath;
     }
 
-    public DashScopeVideoOptions getOptions() {
+    @DeprecatedConfigurationProperty(replacement = CONFIG_PREFIX)
+    @Deprecated(since = "2.0.0", forRemoval = true)
+	public DashScopeVideoOptions getOptions() {
 		return this.options;
 	}
 
 	public void setOptions(DashScopeVideoOptions options) {
 		this.options = options;
 	}
+
+    public String getModel() {
+        return this.options.getModel();
+    }
+
+    public void setModel(String model) {
+        this.options.setModel(model);
+    }
+
+    public DashScopeVideoOptions.InputOptions getInput() {
+        return this.options.getInput();
+    }
+
+    public void setInput(DashScopeVideoOptions.InputOptions input) {
+        this.options.setInput(input);
+    }
+
+    public DashScopeVideoOptions.ParametersOptions getParameters() {
+        return this.options.getParameters();
+    }
+
+    public void setParameters(DashScopeVideoOptions.ParametersOptions parameters) {
+        this.options.setParameters(parameters);
+    }
 
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -7,6 +7,1560 @@
       "description": "Enable DashScope model.",
       "sourceType": "com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionProperties",
       "defaultValue": true
+    },
+    {
+      "name": "spring.ai.dashscope.agent.options.app-id",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.agent.app-id"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.agent.options.session-id",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.agent.session-id"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.agent.options.memory-id",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.agent.memory-id"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.agent.options.model-id",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.agent.model-id"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.agent.options.incremental-output",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.agent.incremental-output"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.agent.options.has-thoughts",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.agent.has-thoughts"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.agent.options.enable-thinking",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.agent.enable-thinking"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.agent.options.images",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.agent.images"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.agent.options.files",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.agent.files"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.agent.options.biz-params",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.agent.biz-params"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.agent.options.rag-options",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.agent.rag-options"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.agent.options.flow-stream-mode",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.agent.flow-stream-mode"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.model",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.model"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.voice",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.voice"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.text-type",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.text-type"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.enable-aigc-tag",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.enable-aigc-tag"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.aigc-propagator",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.aigc-propagator"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.aigc-propagate-id",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.aigc-propagate-id"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.sample-rate",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.sample-rate"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.format",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.format"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.response-format",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.response-format"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.word-timestamp-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.word-timestamp-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.phoneme-timestamp-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.phoneme-timestamp-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.volume",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.volume"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.speed",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.speed"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.rate",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.rate"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.pitch",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.pitch"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.enable-ssml",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.enable-ssml"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.bit-rate",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.bit-rate"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.seed",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.seed"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.language-hints",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.language-hints"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.instruction",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.instruction"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.optimize-instructions",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.optimize-instructions"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.speech.options.language-type",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.speech.language-type"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.model",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.model"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.vocabulary-id",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.vocabulary-id"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.format",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.format"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.sample-rate",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.sample-rate"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.source-language",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.source-language"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.transcription-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.transcription-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.translation-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.translation-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.translation-target-languages",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.translation-target-languages"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.asr-options",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.asr-options"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.max-end-silence",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.max-end-silence"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.modalities",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.modalities"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.audio",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.audio"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.stream",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.stream"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.stream-options",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.stream-options"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.max-tokens",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.max-tokens"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.seed",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.seed"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.temperature",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.temperature"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.top-p",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.top-p"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.presence-penalty",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.presence-penalty"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.top-k",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.top-k"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.repetition-penalty",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.repetition-penalty"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.translation-options",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.translation-options"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.disfluency-removal-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.disfluency-removal-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.language-hints",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.language-hints"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.semantic-punctuation-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.semantic-punctuation-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.max-sentence-silence",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.max-sentence-silence"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.multi-threshold-mode-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.multi-threshold-mode-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.punctuation-prediction-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.punctuation-prediction-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.heartbeat",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.heartbeat"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.inverse-text-normalization-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.inverse-text-normalization-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.resources",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.resources"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.timestamp-alignment-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.timestamp-alignment-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.special-word-filter",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.special-word-filter"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.diarization-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.diarization-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.speaker-count",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.speaker-count"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.audio.transcription.options.channel-id",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.audio.transcription.channel-id"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.translation-options",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.translation-options"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.output-format",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.output-format"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.top-log-probs",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.top-log-probs"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.logprobs",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.logprobs"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.ocr-options",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.ocr-options"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.vl-enable-image-hw-output",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.vl-enable-image-hw-output"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.audio",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.audio"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.stream-options",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.stream-options"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.asr-options",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.asr-options"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.max-input-tokens",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.max-input-tokens"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.modalities",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.modalities"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.model",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.model"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.max-tokens",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.max-tokens"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.stream",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.stream"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.temperature",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.temperature"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.search-options",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.search-options"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.parallel-tool-calls",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.parallel-tool-calls"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.http-headers",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.http-headers"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.top-p",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.top-p"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.top-k",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.top-k"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.stop",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.stop"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.response-format",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.response-format"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.thinking-budget",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.thinking-budget"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.enable-code-interpreter",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.enable-code-interpreter"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.enable-search",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.enable-search"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.repetition-penalty",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.repetition-penalty"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.tools",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.tools"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.tool-choice",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.tool-choice"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.seed",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.seed"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.tool-callbacks",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.tool-callbacks"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.tool-names",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.tool-names"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.internal-tool-execution-enabled",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.internal-tool-execution-enabled"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.tool-context",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.tool-context"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.incremental-output",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.incremental-output"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.vl-high-resolution-images",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.vl-high-resolution-images"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.enable-thinking",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.enable-thinking"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.multi-model",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.multi-model"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.chat.options.extra-body",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.chat.extra-body"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.embedding.options.model",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.embedding.model"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.embedding.options.dimensions",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.embedding.dimensions"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.embedding.options.text-type",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.embedding.text-type"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.embedding.options.output-type",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.embedding.output-type"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.embedding.options.embeddings-path",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.embedding.embeddings-path"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.model",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.model"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.n",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.n"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.width",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.width"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.height",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.height"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.size",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.size"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.style",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.style"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.style-index",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.style-index"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.style-ref-url",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.style-ref-url"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.base-image-url",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.base-image-url"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.images",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.images"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.mask-image-url",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.mask-image-url"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.sketch-image-url",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.sketch-image-url"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.template-image-url",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.template-image-url"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.shoe-image-url",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.shoe-image-url"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.face-image-url",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.face-image-url"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.background-image-url",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.background-image-url"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.foreground-url",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.foreground-url"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.person-image-url",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.person-image-url"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.top-garment-url",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.top-garment-url"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.bottom-garment-url",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.bottom-garment-url"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.coarse-image-url",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.coarse-image-url"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.user-urls",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.user-urls"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.ref-img",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.ref-img"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.predefined-face-id",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.predefined-face-id"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.face-prompt",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.face-prompt"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.bgstyle-scale",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.bgstyle-scale"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.real-person",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.real-person"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.seed",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.seed"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.ref-strength",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.ref-strength"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.response-format",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.response-format"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.ref-mode",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.ref-mode"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.negative-prompt",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.negative-prompt"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.text",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.text"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.prompt-extend",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.prompt-extend"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.watermark",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.watermark"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.function",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.function"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.sketch-weight",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.sketch-weight"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.sketch-extraction",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.sketch-extraction"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.sketch-color",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.sketch-color"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.mask-color",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.mask-color"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.bbox-list",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.bbox-list"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.max-images",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.max-images"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.enable-interleave",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.enable-interleave"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.enable-sequential",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.enable-sequential"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.color-palette",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.color-palette"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.thinking-mode",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.thinking-mode"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.output-ratio",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.output-ratio"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.xscale",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.xscale"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.yscale",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.yscale"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.angle",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.angle"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.left-offset",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.left-offset"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.right-offset",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.right-offset"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.top-offset",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.top-offset"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.bottom-offset",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.bottom-offset"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.best-quality",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.best-quality"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.limit-image-size",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.limit-image-size"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.source-lang",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.source-lang"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.target-lang",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.target-lang"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.ext",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.ext"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.element-list",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.element-list"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.result-type",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.result-type"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.series-amount",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.series-amount"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.aspect-ratio",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.aspect-ratio"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.resolution",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.resolution"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.short-side-size",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.short-side-size"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.scale",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.scale"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.model-version",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.model-version"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.noise-level",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.noise-level"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.ref-prompt-weight",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.ref-prompt-weight"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.reference-edge",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.reference-edge"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.generate-mode",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.generate-mode"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.auxiliary-parameters",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.auxiliary-parameters"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.title",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.title"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.sub-title",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.sub-title"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.body-text",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.body-text"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.prompt-text-zh",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.prompt-text-zh"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.prompt-text-en",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.prompt-text-en"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.wh-ratios",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.wh-ratios"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.lora-name",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.lora-name"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.lora-weight",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.lora-weight"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.ctrl-ratio",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.ctrl-ratio"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.ctrl-step",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.ctrl-step"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.creative-title-layout",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.creative-title-layout"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.fast-mode",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.fast-mode"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.dilate-flag",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.dilate-flag"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.restore-face",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.restore-face"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.gender",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.gender"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.clothes-type",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.clothes-type"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.resources",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.resources"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.skin-retouch",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.skin-retouch"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.steps",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.steps"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.font-name",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.font-name"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.ttf-url",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.ttf-url"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.image-short-size",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.image-short-size"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.alpha-channel",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.alpha-channel"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.training-file-ids",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.training-file-ids"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.invoke-mode",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.invoke-mode"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.image.options.request-type",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.image.request-type"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.embedding.multimodal.options.model",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.embedding.multimodal.model"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.embedding.multimodal.options.dimensions",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.embedding.multimodal.dimensions"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.embedding.multimodal.options.output-type",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.embedding.multimodal.output-type"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.embedding.multimodal.options.fps",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.embedding.multimodal.fps"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.embedding.multimodal.options.instruct",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.embedding.multimodal.instruct"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.rerank.options.top-n",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.rerank.top-n"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.rerank.options.return-documents",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.rerank.return-documents"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.rerank.options.model",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.rerank.model"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.video.options.model",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.video.model"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.video.options.input",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.video.input"
+      }
+    },
+    {
+      "name": "spring.ai.dashscope.video.options.parameters",
+      "deprecation": {
+        "reason": "The .options property segment is deprecated in Spring AI 2.0.",
+        "replacement": "spring.ai.dashscope.video.parameters"
+      }
     }
   ],
   "hints": []

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/test/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopePropertiesTests.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/test/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopePropertiesTests.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.autoconfigure.dashscope;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DashScopePropertiesTests {
+
+	@Test
+	void chatPropertiesBindFlatOptions() {
+		DashScopeChatProperties properties = bind(DashScopeChatProperties.CONFIG_PREFIX,
+				DashScopeChatProperties.class,
+				"spring.ai.dashscope.chat.model", "qwen-test",
+				"spring.ai.dashscope.chat.temperature", "0.7",
+				"spring.ai.dashscope.chat.enable-search", "true");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("qwen-test");
+		assertThat(properties.toOptions().getTemperature()).isEqualTo(0.7d);
+		assertThat(properties.toOptions().getEnableSearch()).isTrue();
+	}
+
+	@Test
+	void chatPropertiesStillBindLegacyOptions() {
+		DashScopeChatProperties properties = bind(DashScopeChatProperties.CONFIG_PREFIX,
+				DashScopeChatProperties.class,
+				"spring.ai.dashscope.chat.options.model", "legacy-qwen");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("legacy-qwen");
+	}
+
+	@Test
+	void audioSpeechPropertiesBindFlatOptions() {
+		DashScopeAudioSpeechProperties properties = bind(DashScopeAudioSpeechProperties.CONFIG_PREFIX,
+				DashScopeAudioSpeechProperties.class,
+				"spring.ai.dashscope.audio.speech.model", "cosyvoice-test",
+				"spring.ai.dashscope.audio.speech.voice", "longxiaochun",
+				"spring.ai.dashscope.audio.speech.sample-rate", "16000");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("cosyvoice-test");
+		assertThat(properties.toOptions().getVoice()).isEqualTo("longxiaochun");
+		assertThat(properties.toOptions().getSampleRate()).isEqualTo(16000);
+	}
+
+	@Test
+	void audioSpeechPropertiesStillBindLegacyOptions() {
+		DashScopeAudioSpeechProperties properties = bind(DashScopeAudioSpeechProperties.CONFIG_PREFIX,
+				DashScopeAudioSpeechProperties.class,
+				"spring.ai.dashscope.audio.speech.options.voice", "legacy-voice");
+
+		assertThat(properties.toOptions().getVoice()).isEqualTo("legacy-voice");
+	}
+
+	@Test
+	void audioTranscriptionPropertiesBindFlatOptions() {
+		DashScopeAudioTranscriptionProperties properties = bind(DashScopeAudioTranscriptionProperties.CONFIG_PREFIX,
+				DashScopeAudioTranscriptionProperties.class,
+				"spring.ai.dashscope.audio.transcription.model", "paraformer-test",
+				"spring.ai.dashscope.audio.transcription.translation-enabled", "true",
+				"spring.ai.dashscope.audio.transcription.channel-id[0]", "1");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("paraformer-test");
+		assertThat(properties.toOptions().getTranslationEnabled()).isTrue();
+		assertThat(properties.toOptions().getChannelId()).containsExactly(1);
+	}
+
+	@Test
+	void audioTranscriptionPropertiesStillBindLegacyOptions() {
+		DashScopeAudioTranscriptionProperties properties = bind(DashScopeAudioTranscriptionProperties.CONFIG_PREFIX,
+				DashScopeAudioTranscriptionProperties.class,
+				"spring.ai.dashscope.audio.transcription.options.source-language", "en");
+
+		assertThat(properties.toOptions().getSourceLanguage()).isEqualTo("en");
+	}
+
+	@Test
+	void embeddingPropertiesBindFlatOptions() {
+		DashScopeEmbeddingProperties properties = bind(DashScopeEmbeddingProperties.CONFIG_PREFIX,
+				DashScopeEmbeddingProperties.class,
+				"spring.ai.dashscope.embedding.model", "embedding-test",
+				"spring.ai.dashscope.embedding.dimensions", "256",
+				"spring.ai.dashscope.embedding.embeddings-path", "/compatible-mode/v1/embeddings");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("embedding-test");
+		assertThat(properties.toOptions().getDimensions()).isEqualTo(256);
+		assertThat(properties.getEmbeddingsPath()).isEqualTo("/compatible-mode/v1/embeddings");
+		assertThat(properties.toOptions().getEmbeddingsPath()).isEqualTo("/compatible-mode/v1/embeddings");
+	}
+
+	@Test
+	void embeddingPropertiesStillBindLegacyOptions() {
+		DashScopeEmbeddingProperties properties = bind(DashScopeEmbeddingProperties.CONFIG_PREFIX,
+				DashScopeEmbeddingProperties.class,
+				"spring.ai.dashscope.embedding.options.dimensions", "128");
+
+		assertThat(properties.toOptions().getDimensions()).isEqualTo(128);
+	}
+
+	@Test
+	void imagePropertiesBindFlatOptions() {
+		DashScopeImageProperties properties = bind(DashScopeImageProperties.CONFIG_PREFIX,
+				DashScopeImageProperties.class,
+				"spring.ai.dashscope.image.model", "wanx-test",
+				"spring.ai.dashscope.image.n", "2",
+				"spring.ai.dashscope.image.size", "1024*1024");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("wanx-test");
+		assertThat(properties.toOptions().getN()).isEqualTo(2);
+		assertThat(properties.toOptions().getSize()).isEqualTo("1024*1024");
+	}
+
+	@Test
+	void imagePropertiesStillBindLegacyOptions() {
+		DashScopeImageProperties properties = bind(DashScopeImageProperties.CONFIG_PREFIX,
+				DashScopeImageProperties.class,
+				"spring.ai.dashscope.image.options.negative-prompt", "legacy-negative");
+
+		assertThat(properties.toOptions().getNegativePrompt()).isEqualTo("legacy-negative");
+	}
+
+	@Test
+	void multimodalEmbeddingPropertiesBindFlatOptions() {
+		DashScopeMultimodalEmbeddingProperties properties = bind(DashScopeMultimodalEmbeddingProperties.CONFIG_PREFIX,
+				DashScopeMultimodalEmbeddingProperties.class,
+				"spring.ai.dashscope.embedding.multimodal.model", "vision-embedding-test",
+				"spring.ai.dashscope.embedding.multimodal.fps", "12.5");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("vision-embedding-test");
+		assertThat(properties.toOptions().getFps()).isEqualTo(12.5f);
+	}
+
+	@Test
+	void multimodalEmbeddingPropertiesStillBindLegacyOptions() {
+		DashScopeMultimodalEmbeddingProperties properties = bind(DashScopeMultimodalEmbeddingProperties.CONFIG_PREFIX,
+				DashScopeMultimodalEmbeddingProperties.class,
+				"spring.ai.dashscope.embedding.multimodal.options.output-type", "dense");
+
+		assertThat(properties.toOptions().getOutputType()).isEqualTo("dense");
+	}
+
+	@Test
+	void rerankPropertiesBindFlatOptions() {
+		DashScopeRerankProperties properties = bind(DashScopeRerankProperties.CONFIG_PREFIX,
+				DashScopeRerankProperties.class,
+				"spring.ai.dashscope.rerank.model", "rerank-test",
+				"spring.ai.dashscope.rerank.top-n", "7",
+				"spring.ai.dashscope.rerank.return-documents", "true");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("rerank-test");
+		assertThat(properties.toOptions().getTopN()).isEqualTo(7);
+		assertThat(properties.toOptions().getReturnDocuments()).isTrue();
+	}
+
+	@Test
+	void rerankPropertiesStillBindLegacyOptions() {
+		DashScopeRerankProperties properties = bind(DashScopeRerankProperties.CONFIG_PREFIX,
+				DashScopeRerankProperties.class,
+				"spring.ai.dashscope.rerank.options.top-n", "3");
+
+		assertThat(properties.toOptions().getTopN()).isEqualTo(3);
+	}
+
+	@Test
+	void agentPropertiesBindFlatOptions() {
+		DashScopeAgentProperties properties = bind(DashScopeAgentProperties.CONFIG_PREFIX,
+				DashScopeAgentProperties.class,
+				"spring.ai.dashscope.agent.app-id", "app-test",
+				"spring.ai.dashscope.agent.model-id", "qwen-agent",
+				"spring.ai.dashscope.agent.enable-thinking", "true");
+
+		assertThat(properties.toOptions().getAppId()).isEqualTo("app-test");
+		assertThat(properties.toOptions().getModelId()).isEqualTo("qwen-agent");
+		assertThat(properties.toOptions().getEnableThinking()).isTrue();
+	}
+
+	@Test
+	void agentPropertiesStillBindLegacyOptions() {
+		DashScopeAgentProperties properties = bind(DashScopeAgentProperties.CONFIG_PREFIX,
+				DashScopeAgentProperties.class,
+				"spring.ai.dashscope.agent.options.app-id", "legacy-app");
+
+		assertThat(properties.toOptions().getAppId()).isEqualTo("legacy-app");
+	}
+
+	@Test
+	void videoPropertiesBindFlatOptions() {
+		DashScopeVideoProperties properties = bind(DashScopeVideoProperties.CONFIG_PREFIX,
+				DashScopeVideoProperties.class,
+				"spring.ai.dashscope.video.model", "wan-video-test");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("wan-video-test");
+	}
+
+	@Test
+	void videoPropertiesStillBindLegacyOptions() {
+		DashScopeVideoProperties properties = bind(DashScopeVideoProperties.CONFIG_PREFIX,
+				DashScopeVideoProperties.class,
+				"spring.ai.dashscope.video.options.model", "legacy-video");
+
+		assertThat(properties.toOptions().getModel()).isEqualTo("legacy-video");
+	}
+
+	@Test
+	void additionalMetadataContainsLegacyOptionsReplacements() throws IOException {
+		String metadata = additionalMetadata();
+
+		assertThat(metadata)
+			.contains("spring.ai.dashscope.chat.options.model", "spring.ai.dashscope.chat.model")
+			.contains("spring.ai.dashscope.image.options.request-type", "spring.ai.dashscope.image.request-type")
+			.contains("spring.ai.dashscope.video.options.model", "spring.ai.dashscope.video.model");
+	}
+
+	private static <T> T bind(String prefix, Class<T> propertiesType, String... pairs) {
+		Map<String, String> source = new LinkedHashMap<>();
+		for (int i = 0; i < pairs.length; i += 2) {
+			source.put(pairs[i], pairs[i + 1]);
+		}
+		return new Binder(new MapConfigurationPropertySource(source)).bind(prefix, propertiesType).get();
+	}
+
+	private static String additionalMetadata() throws IOException {
+		try (var inputStream = DashScopePropertiesTests.class.getClassLoader()
+			.getResourceAsStream("META-INF/additional-spring-configuration-metadata.json")) {
+			assertThat(inputStream).isNotNull();
+			return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+		}
+	}
+
+}

--- a/models/dashscope-sdk/src/main/java/com/alibaba/cloud/ai/dashscope/sdk/audio/transcription/DashScopeSdkAudioTranscriptionModel.java
+++ b/models/dashscope-sdk/src/main/java/com/alibaba/cloud/ai/dashscope/sdk/audio/transcription/DashScopeSdkAudioTranscriptionModel.java
@@ -87,7 +87,7 @@ public class DashScopeSdkAudioTranscriptionModel implements TranscriptionModel {
 		List<String> fileUrls = resolveFileUrls(prompt, options);
 		if (CollectionUtils.isEmpty(fileUrls)) {
 			throw new IllegalArgumentException(
-					"No valid file URLs found. Configure spring.ai.dashscope.sdk.audio.transcription.options.file-urls or use URL resource.");
+					"No valid file URLs found. Configure spring.ai.dashscope.sdk.audio.transcription.file-urls or use URL resource.");
 		}
 
 		TranscriptionParam request = createRequest(fileUrls, options);


### PR DESCRIPTION
## Summary

This PR aligns DashScope and DashScope SDK auto-configuration properties with the Spring AI 2.x property migration by supporting flat model option properties without the `.options` segment.

## Changes

- Added flat property bindings for DashScope and DashScope SDK model options.
  - Before: `spring.ai.dashscope.chat.options.n`
  - After: `spring.ai.dashscope.chat.n`
- Kept legacy `.options.*` properties bindable for backward compatibility.
- Updated auto-configurations to pass `toOptions()` into model builders.
- Added deprecated configuration metadata entries for legacy `.options.*` keys with replacement hints.
- Updated the DashScope SDK audio transcription property message from `.options.file-urls` to `.file-urls`.
- Added property binding tests for flat and legacy option keys across DashScope and DashScope SDK auto-configurations.

Closes #267 