### PR TITLE
Stabilize tests that depend on external services

### DIFF
--- a/document-readers/spring-ai-alibaba-starter-document-reader-arxiv/src/main/java/com/alibaba/cloud/ai/reader/arxiv/ArxivDocumentReader.java
+++ b/document-readers/spring-ai-alibaba-starter-document-reader-arxiv/src/main/java/com/alibaba/cloud/ai/reader/arxiv/ArxivDocumentReader.java
@@ -60,12 +60,23 @@ public class ArxivDocumentReader implements DocumentReader {
 	 * @param maxSize maximum number of documents to retrieve
 	 */
 	public ArxivDocumentReader(String queryString, int maxSize) {
+		this(queryString, maxSize, new PagePdfDocumentParser());
+	}
+
+	/**
+	 * Create an arXiv document reader with a custom document parser
+	 * @param queryString arXiv query string
+	 * @param maxSize maximum number of documents to retrieve
+	 * @param parser parser used for downloaded PDF content
+	 */
+	public ArxivDocumentReader(String queryString, int maxSize, DocumentParser parser) {
 		Assert.hasText(queryString, "Query string must not be empty");
 		Assert.isTrue(maxSize > 0, "Max size must be greater than 0");
+		Assert.notNull(parser, "Document parser must not be null");
 
 		this.queryString = queryString;
 		this.maxSize = maxSize;
-		this.parser = (DocumentParser) new PagePdfDocumentParser();
+		this.parser = parser;
 		this.arxivClient = new ArxivClient();
 		this.arxivResource = new ArxivResource(queryString, maxSize);
 	}

--- a/document-readers/spring-ai-alibaba-starter-document-reader-arxiv/src/main/java/com/alibaba/cloud/ai/reader/arxiv/client/ArxivClient.java
+++ b/document-readers/spring-ai-alibaba-starter-document-reader-arxiv/src/main/java/com/alibaba/cloud/ai/reader/arxiv/client/ArxivClient.java
@@ -54,7 +54,7 @@ public class ArxivClient {
 
 	private static final Logger logger = LoggerFactory.getLogger(ArxivClient.class);
 
-	private static final String QUERY_URL_FORMAT = "https://export.arxiv.org/api/query?%s";
+	private static final String DEFAULT_QUERY_URL_FORMAT = "https://export.arxiv.org/api/query?%s";
 
 	private static final DateTimeFormatter ATOM_DATE_FORMAT = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
@@ -70,14 +70,21 @@ public class ArxivClient {
 
 	private final DocumentBuilder documentBuilder;
 
+	private final String queryUrlFormat;
+
 	public ArxivClient() {
 		this(100, 3.0f, 3);
 	}
 
 	public ArxivClient(int pageSize, float delaySeconds, int numRetries) {
+		this(pageSize, delaySeconds, numRetries, DEFAULT_QUERY_URL_FORMAT);
+	}
+
+	protected ArxivClient(int pageSize, float delaySeconds, int numRetries, String queryUrlFormat) {
 		this.pageSize = pageSize;
 		this.delaySeconds = delaySeconds;
 		this.numRetries = numRetries;
+		this.queryUrlFormat = queryUrlFormat;
 		this.httpClient = HttpClient.newBuilder()
 			.version(HttpClient.Version.HTTP_2)
 			.connectTimeout(Duration.ofSeconds(10))
@@ -120,7 +127,7 @@ public class ArxivClient {
 					URLEncoder.encode(e.getValue(), StandardCharsets.UTF_8)))
 			.collect(Collectors.joining("&"));
 
-		return String.format(QUERY_URL_FORMAT, queryString);
+		return String.format(queryUrlFormat, queryString);
 	}
 
 	/**

--- a/document-readers/spring-ai-alibaba-starter-document-reader-arxiv/src/test/java/com/alibaba/cloud/ai/reader/arxiv/ArxivClientTest.java
+++ b/document-readers/spring-ai-alibaba-starter-document-reader-arxiv/src/test/java/com/alibaba/cloud/ai/reader/arxiv/ArxivClientTest.java
@@ -16,9 +16,13 @@
 package com.alibaba.cloud.ai.reader.arxiv;
 
 import com.alibaba.cloud.ai.reader.arxiv.client.*;
+import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -121,62 +125,67 @@ public class ArxivClientTest {
 
 	@Test
 	public void testPagination() throws IOException {
-		// Create client with longer delay to avoid rate limiting
-		ArxivClient client = new ArxivClient(20, 5.0f, 3); // Set page size to 20
+		HttpServer server = createPaginationServer();
+		server.start();
+		try {
+			ArxivClient client = new TestArxivClient(1, 0.0f, 0,
+					"http://localhost:" + server.getAddress().getPort() + "/api/query?%s");
 
-		ArxivSearch search = new ArxivSearch();
-		// Use a more specific and reliable query that should always return results
-		search.setQuery("cat:cs.AI AND ti:\"machine learning\"");
-		// Set max results to a number larger than page size to ensure we get multiple
-		// pages
-		search.setMaxResults(50); // Request more than one page
-		// Set sort order to ensure consistent results
-		search.setSortBy(ArxivSortCriterion.RELEVANCE);
-		search.setSortOrder(ArxivSortOrder.DESCENDING);
+			ArxivSearch search = new ArxivSearch();
+			search.setIdList(List.of("2501.01639v1", "2212.12633v2"));
+			search.setMaxResults(2); // Request more than one page
 
-		// Get first page
-		Iterator<ArxivResult> firstPage = client.results(search, 0);
-		List<ArxivResult> firstPageResults = new ArrayList<>();
+			// Get first page
+			Iterator<ArxivResult> firstPage = client.results(search, 0);
+			List<ArxivResult> firstPageResults = new ArrayList<>();
 
-		// Only take at most pageSize (20) items from the iterator
-		int count = 0;
-		while (firstPage.hasNext() && count < 20) {
-			firstPageResults.add(firstPage.next());
-			count++;
+			// Only take at most pageSize (1) item from the iterator
+			int count = 0;
+			while (count < 1 && firstPage.hasNext()) {
+				firstPageResults.add(firstPage.next());
+				count++;
+			}
+
+			// Print debug information
+			System.out.println("First page results count: " + firstPageResults.size());
+
+			// Verify we have results from first page
+			assertTrue(firstPageResults.size() > 0, "First page should return results");
+			assertTrue(firstPageResults.size() <= 1, "First page should not exceed page size");
+
+			// Get second page
+			Iterator<ArxivResult> secondPage = client.results(search, firstPageResults.size());
+			List<ArxivResult> secondPageResults = new ArrayList<>();
+
+			// Take only up to 1 result from second page
+			count = 0;
+			while (count < 1 && secondPage.hasNext()) {
+				secondPageResults.add(secondPage.next());
+				count++;
+			}
+
+			System.out.println("Second page results count: " + secondPageResults.size());
+
+			// Verify we have results from second page
+			assertTrue(secondPageResults.size() > 0, "Second page should return results");
+			assertTrue(secondPageResults.size() <= 1, "Second page should not exceed page size");
+
+			// Verify results are different
+			Set<String> firstPageIds = firstPageResults.stream()
+				.map(ArxivResult::getEntryId)
+				.collect(Collectors.toSet());
+			Set<String> secondPageIds = secondPageResults.stream()
+				.map(ArxivResult::getEntryId)
+				.collect(Collectors.toSet());
+
+			// Check for any overlap between pages
+			Set<String> intersection = new HashSet<>(firstPageIds);
+			intersection.retainAll(secondPageIds);
+			assertTrue(intersection.isEmpty(), "Pages should not have overlapping results");
 		}
-
-		// Print debug information
-		System.out.println("First page results count: " + firstPageResults.size());
-
-		// Verify we have results from first page
-		assertTrue(firstPageResults.size() > 0, "First page should return results");
-		assertTrue(firstPageResults.size() <= 20, "First page should not exceed page size");
-
-		// Get second page
-		Iterator<ArxivResult> secondPage = client.results(search, firstPageResults.size());
-		List<ArxivResult> secondPageResults = new ArrayList<>();
-
-		// Take only up to 20 results from second page
-		count = 0;
-		while (secondPage.hasNext() && count < 20) {
-			secondPageResults.add(secondPage.next());
-			count++;
+		finally {
+			server.stop(0);
 		}
-
-		System.out.println("Second page results count: " + secondPageResults.size());
-
-		// Verify we have results from second page
-		assertTrue(secondPageResults.size() > 0, "Second page should return results");
-		assertTrue(secondPageResults.size() <= 20, "Second page should not exceed page size");
-
-		// Verify results are different
-		Set<String> firstPageIds = firstPageResults.stream().map(ArxivResult::getEntryId).collect(Collectors.toSet());
-		Set<String> secondPageIds = secondPageResults.stream().map(ArxivResult::getEntryId).collect(Collectors.toSet());
-
-		// Check for any overlap between pages
-		Set<String> intersection = new HashSet<>(firstPageIds);
-		intersection.retainAll(secondPageIds);
-		assertTrue(intersection.isEmpty(), "Pages should not have overlapping results");
 	}
 
 	@Test
@@ -219,6 +228,48 @@ public class ArxivClientTest {
 		Files.deleteIfExists(defaultPath);
 		Files.deleteIfExists(customPath);
 		Files.deleteIfExists(tempDir);
+	}
+
+	private static HttpServer createPaginationServer() throws IOException {
+		HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+		server.createContext("/api/query", exchange -> {
+			String query = exchange.getRequestURI().getRawQuery();
+			String id = query != null && query.contains("start=1") ? "2212.12633v2" : "2501.01639v1";
+			byte[] body = atomFeed(id).getBytes(StandardCharsets.UTF_8);
+			exchange.getResponseHeaders().set("Content-Type", "application/atom+xml; charset=UTF-8");
+			exchange.sendResponseHeaders(200, body.length);
+			try (OutputStream outputStream = exchange.getResponseBody()) {
+				outputStream.write(body);
+			}
+		});
+		return server;
+	}
+
+	private static String atomFeed(String id) {
+		return """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<feed xmlns="http://www.w3.org/2005/Atom" xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">
+					<opensearch:totalResults>2</opensearch:totalResults>
+					<entry>
+						<id>https://arxiv.org/abs/%s</id>
+						<title>Test paper %s</title>
+						<summary>Deterministic pagination fixture.</summary>
+						<updated>2025-01-01T00:00:00Z</updated>
+						<published>2025-01-01T00:00:00Z</published>
+						<author><name>Test Author</name></author>
+						<category term="cs.AI" />
+						<link href="https://arxiv.org/abs/%s" rel="alternate" type="text/html" />
+					</entry>
+				</feed>
+				""".formatted(id, id, id);
+	}
+
+	private static final class TestArxivClient extends ArxivClient {
+
+		private TestArxivClient(int pageSize, float delaySeconds, int numRetries, String queryUrlFormat) {
+			super(pageSize, delaySeconds, numRetries, queryUrlFormat);
+		}
+
 	}
 
 }

--- a/document-readers/spring-ai-alibaba-starter-document-reader-arxiv/src/test/java/com/alibaba/cloud/ai/reader/arxiv/ArxivDocumentReaderTest.java
+++ b/document-readers/spring-ai-alibaba-starter-document-reader-arxiv/src/test/java/com/alibaba/cloud/ai/reader/arxiv/ArxivDocumentReaderTest.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.reader.arxiv;
 
+import com.alibaba.cloud.ai.document.DocumentParser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.springframework.ai.document.Document;
@@ -47,7 +48,8 @@ public class ArxivDocumentReaderTest {
 	@Test
 	public void testDocumentReader() {
 		// Create document reader
-		ArxivDocumentReader reader = new ArxivDocumentReader(TEST_QUERY, MAX_SIZE);
+		DocumentParser parser = inputStream -> List.of(new Document("Parsed arXiv PDF content"));
+		ArxivDocumentReader reader = new ArxivDocumentReader(TEST_QUERY, MAX_SIZE, parser);
 
 		// Get documents
 		List<Document> documents = reader.get();

--- a/memory-repository/spring-ai-alibaba-model-chat-memory-repository-memcached/src/test/java/memcached/MemcachedChatMemoryRepositoryTest.java
+++ b/memory-repository/spring-ai-alibaba-model-chat-memory-repository-memcached/src/test/java/memcached/MemcachedChatMemoryRepositoryTest.java
@@ -45,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * environment
  */
 @SpringBootTest(classes = MemcachedTestConfiguration.class)
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 class MemcachedChatMemoryRepositoryTest {
 
 	private static final int MEMCACHED_PORT = 11211;

--- a/memory-repository/spring-ai-alibaba-model-chat-memory-repository-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/JedisRedisChatMemoryRepositoryTest.java
+++ b/memory-repository/spring-ai-alibaba-model-chat-memory-repository-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/JedisRedisChatMemoryRepositoryTest.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration test using Testcontainers to automatically manage Redis test environment
  */
 @SpringBootTest(classes = JedisRedisChatMemoryRepositoryTest.TestConfiguration.class)
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 class JedisRedisChatMemoryRepositoryTest {
 
 	private static final int REDIS_PORT = 6379;

--- a/memory-repository/spring-ai-alibaba-model-chat-memory-repository-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/LettuceRedisChatMemoryRepositoryTest.java
+++ b/memory-repository/spring-ai-alibaba-model-chat-memory-repository-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/LettuceRedisChatMemoryRepositoryTest.java
@@ -47,7 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since 2025/7/31 16:48
  */
 @SpringBootTest(classes = LettuceRedisChatMemoryRepositoryTest.TestConfiguration.class)
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 public class LettuceRedisChatMemoryRepositoryTest {
 
 	private static final int REDIS_PORT = 6379;

--- a/memory-repository/spring-ai-alibaba-model-chat-memory-repository-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/RedissonRedisChatMemoryRepositoryTest.java
+++ b/memory-repository/spring-ai-alibaba-model-chat-memory-repository-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/RedissonRedisChatMemoryRepositoryTest.java
@@ -47,7 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since 2025/7/31 16:47
  */
 @SpringBootTest(classes = RedissonRedisChatMemoryRepositoryTest.TestConfiguration.class)
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 public class RedissonRedisChatMemoryRepositoryTest {
 
 	private static final int REDIS_PORT = 6379;

--- a/memory-repository/spring-ai-alibaba-model-chat-memory-repository-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/ssl/SslJedisRedisChatMemoryTest.java
+++ b/memory-repository/spring-ai-alibaba-model-chat-memory-repository-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/ssl/SslJedisRedisChatMemoryTest.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableAutoConfiguration
 @Import(SslAutoConfiguration.class)
 @SpringBootTest(classes = SslJedisRedisChatMemoryTest.TestConfiguration.class)
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 public class SslJedisRedisChatMemoryTest {
 
 	private static final int REDIS_PORT = 6379;

--- a/memory-repository/spring-ai-alibaba-model-chat-memory-repository-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/ssl/SslLettuceRedisChatMemoryTest.java
+++ b/memory-repository/spring-ai-alibaba-model-chat-memory-repository-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/ssl/SslLettuceRedisChatMemoryTest.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableAutoConfiguration
 @Import(SslAutoConfiguration.class)
 @SpringBootTest(classes = SslLettuceRedisChatMemoryTest.TestConfiguration.class)
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 public class SslLettuceRedisChatMemoryTest {
 
 	private static final int REDIS_PORT = 6379;

--- a/memory-repository/spring-ai-alibaba-model-chat-memory-repository-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/ssl/SslRedissonRedisChatMemoryTest.java
+++ b/memory-repository/spring-ai-alibaba-model-chat-memory-repository-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/ssl/SslRedissonRedisChatMemoryTest.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableAutoConfiguration
 @Import(SslAutoConfiguration.class)
 @SpringBootTest(classes = SslRedissonRedisChatMemoryTest.TestConfiguration.class)
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 public class SslRedissonRedisChatMemoryTest {
 
 	private static final int REDIS_PORT = 6379;


### PR DESCRIPTION
## Summary
- make arXiv pagination coverage deterministic with a local Atom fixture instead of live search ordering
- allow ArxivDocumentReader tests to inject a parser so they avoid noisy upstream PDFBox layout errors
- skip Redis and Memcached Testcontainers suites when Docker is unavailable

## Verification
- mvn -pl document-readers/spring-ai-alibaba-starter-document-reader-arxiv test
- mvn -pl memory-repository/spring-ai-alibaba-model-chat-memory-repository-memcached test
- mvn -pl memory-repository/spring-ai-alibaba-model-chat-memory-repository-redis test

## Notes
- Container-backed tests still run normally when Docker is available.
- In Docker-less environments, Testcontainers reports skipped tests instead of failing the module build.