### PR TITLE
fix(dashscope): ingest documents into existing pipelines

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -374,6 +374,29 @@ public class DashScopeApi {
 	}
 
 	public void upsertPipeline(List<Document> documents, DashScopeStoreOptions storeOptions) {
+		DashScopeApiSpec.UpsertPipelineRequest upsertPipelineRequest = createUpsertPipelineRequest(documents,
+				storeOptions);
+		ResponseEntity<DashScopeApiSpec.UpsertPipelineResponse> upsertPipelineResponse = this.restClient.put()
+			.uri(PIPELINE_RESTFUL_URL)
+			.body(upsertPipelineRequest)
+			.retrieve()
+			.toEntity(DashScopeApiSpec.UpsertPipelineResponse.class);
+		if (upsertPipelineResponse.getBody() == null
+				|| !"SUCCESS".equalsIgnoreCase(upsertPipelineResponse.getBody().status())) {
+			throw new DashScopeException(ErrorCodeEnum.CREATE_INDEX_ERROR);
+		}
+		String pipelineId = upsertPipelineResponse.getBody().id();
+		addPipelineDocuments(pipelineId, upsertPipelineRequest);
+	}
+
+	public void addPipelineDocuments(String pipelineId, List<Document> documents, DashScopeStoreOptions storeOptions) {
+		DashScopeApiSpec.UpsertPipelineRequest upsertPipelineRequest = createUpsertPipelineRequest(documents,
+				storeOptions);
+		addPipelineDocuments(pipelineId, upsertPipelineRequest);
+	}
+
+	private DashScopeApiSpec.UpsertPipelineRequest createUpsertPipelineRequest(List<Document> documents,
+			DashScopeStoreOptions storeOptions) {
 		String embeddingModelName = (storeOptions.getEmbeddingOptions() == null ? DEFAULT_EMBEDDING_MODEL
 				: storeOptions.getEmbeddingOptions().getModel());
 		DashScopeApiSpec.EmbeddingConfiguredTransformations embeddingConfig = new DashScopeApiSpec.EmbeddingConfiguredTransformations(
@@ -413,19 +436,13 @@ public class DashScopeApi {
 				Arrays.asList(embeddingConfig, parserConfig, retrieverConfig),
                 List.of(new DashScopeApiSpec.DataSourcesConfig("DATA_CENTER_FILE",
                         new DashScopeApiSpec.DataSourcesConfig.DataSourcesComponent(documentIdList))),
-                List.of(new DashScopeApiSpec.DataSinksConfig("BUILT_IN", null))
+                 List.of(new DashScopeApiSpec.DataSinksConfig("BUILT_IN", null))
 
 		);
-		ResponseEntity<DashScopeApiSpec.UpsertPipelineResponse> upsertPipelineResponse = this.restClient.put()
-			.uri(PIPELINE_RESTFUL_URL)
-			.body(upsertPipelineRequest)
-			.retrieve()
-			.toEntity(DashScopeApiSpec.UpsertPipelineResponse.class);
-		if (upsertPipelineResponse.getBody() == null
-				|| !"SUCCESS".equalsIgnoreCase(upsertPipelineResponse.getBody().status())) {
-			throw new DashScopeException(ErrorCodeEnum.CREATE_INDEX_ERROR);
-		}
-		String pipelineId = upsertPipelineResponse.getBody().id();
+		return upsertPipelineRequest;
+	}
+
+	private void addPipelineDocuments(String pipelineId, DashScopeApiSpec.UpsertPipelineRequest upsertPipelineRequest) {
 		ResponseEntity<DashScopeApiSpec.StartPipelineResponse> startPipelineResponse = this.restClient.post()
 			.uri(MANAGED_INGEST_PIPELINE_RESTFUL_URL, pipelineId)
 			.body(upsertPipelineRequest)

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/rag/DashScopeCloudStore.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/rag/DashScopeCloudStore.java
@@ -23,6 +23,7 @@ import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -65,6 +66,11 @@ public class DashScopeCloudStore implements VectorStore {
 			.collect(Collectors.toList());
 		if (documentIdList == null || documentIdList.isEmpty()) {
 			throw new DashScopeException("document's id must not be null");
+		}
+		String pipelineId = dashScopeApi.getPipelineIdByName(options.getIndexName());
+		if (StringUtils.hasText(pipelineId)) {
+			dashScopeApi.addPipelineDocuments(pipelineId, documents, options);
+			return;
 		}
 		dashScopeApi.upsertPipeline(documents, options);
 	}

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/rag/DashScopeCloudStoreTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/rag/DashScopeCloudStoreTests.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -87,7 +88,27 @@ class DashScopeCloudStoreTests {
 	}
 
 	@Test
-	void testAddDocumentsSuccessfully() {
+	void testAddDocumentsToExistingPipelineSuccessfully() {
+		// Create test documents
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put("key", "value");
+
+		List<Document> documents = Arrays.asList(new Document("id1", "content1", metadata),
+				new Document("id2", "content2", metadata));
+
+		// Execute add operation
+		cloudStore.add(documents);
+
+		// Verify API call
+		verify(dashScopeApi).addPipelineDocuments(eq(TEST_PIPELINE_ID), eq(documents), eq(options));
+		verify(dashScopeApi, never()).upsertPipeline(eq(documents), eq(options));
+	}
+
+	@Test
+	void testCreatePipelineWhenAddingDocumentsToNewIndex() {
+		// Mock non-existent index scenario
+		when(dashScopeApi.getPipelineIdByName(TEST_INDEX_NAME)).thenReturn(null);
+
 		// Create test documents
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put("key", "value");


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR fixes DashScope cloud store document ingestion for an existing Bailian pipeline. In `spring-ai-alibaba-dashscope:1.1.2.3`, `DashScopeCloudStore.add()` always calls `DashScopeApi.upsertPipeline()`, which first sends `PUT /api/v1/indices/pipeline`. When the same `indexName` already exists, Bailian rejects the second create request with `PipelineNameAlreadyExists`, so subsequent document ingestion fails before reaching `managed_ingest`.

### Does this pull request fix one issue?

Related to alibaba/spring-ai-alibaba#4766

### Describe how you did it

- Let `DashScopeCloudStore.add()` query the existing pipeline id by `indexName` before ingesting documents.
- If the pipeline already exists, call the new `DashScopeApi.addPipelineDocuments(...)` path, which directly posts to `managed_ingest`.
- If the pipeline does not exist, keep the existing `upsertPipeline(...)` create-and-ingest flow.
- Extracted the shared pipeline request construction and managed ingest call inside `DashScopeApi` so the new and existing paths use the same request payload.
- Added regression coverage for both existing-pipeline ingestion and new-pipeline creation.

### Describe how to verify it

```bash
mvn -pl models/dashscope -Dtest=DashScopeCloudStoreTests test
mvn -pl models/dashscope -DskipTests package
git diff --check
```

### Special notes for reviews

The PR targets `1.1.2.3-release` because the linked issue reports the problem against `spring-ai-alibaba-dashscope:1.1.2.3`. The repository workflow only matches `main`, `1.1.x`, and `2.x` for build/test/license/secret checks, while the remote currently has `1.1.2.3-release` but no `1.1.x` branch, so this PR only receives the CLA check from GitHub Actions.