### PR TITLE
fix(dashscope): reuse existing pipelines for ingest

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -416,6 +416,20 @@ public class DashScopeApi {
                 List.of(new DashScopeApiSpec.DataSinksConfig("BUILT_IN", null))
 
 		);
+		String pipelineId = getPipelineIdByName(storeOptions.getIndexName());
+		if (!StringUtils.hasText(pipelineId)) {
+			pipelineId = createPipeline(upsertPipelineRequest);
+		}
+		if (!StringUtils.hasText(pipelineId)) {
+			pipelineId = getPipelineIdByName(storeOptions.getIndexName());
+		}
+		if (!StringUtils.hasText(pipelineId)) {
+			throw new DashScopeException(ErrorCodeEnum.CREATE_INDEX_ERROR);
+		}
+		startManagedIngest(pipelineId, upsertPipelineRequest);
+	}
+
+	private String createPipeline(DashScopeApiSpec.UpsertPipelineRequest upsertPipelineRequest) {
 		ResponseEntity<DashScopeApiSpec.UpsertPipelineResponse> upsertPipelineResponse = this.restClient.put()
 			.uri(PIPELINE_RESTFUL_URL)
 			.body(upsertPipelineRequest)
@@ -423,9 +437,12 @@ public class DashScopeApi {
 			.toEntity(DashScopeApiSpec.UpsertPipelineResponse.class);
 		if (upsertPipelineResponse.getBody() == null
 				|| !"SUCCESS".equalsIgnoreCase(upsertPipelineResponse.getBody().status())) {
-			throw new DashScopeException(ErrorCodeEnum.CREATE_INDEX_ERROR);
+			return null;
 		}
-		String pipelineId = upsertPipelineResponse.getBody().id();
+		return upsertPipelineResponse.getBody().id();
+	}
+
+	private void startManagedIngest(String pipelineId, DashScopeApiSpec.UpsertPipelineRequest upsertPipelineRequest) {
 		ResponseEntity<DashScopeApiSpec.StartPipelineResponse> startPipelineResponse = this.restClient.post()
 			.uri(MANAGED_INGEST_PIPELINE_RESTFUL_URL, pipelineId)
 			.body(upsertPipelineRequest)

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApiTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApiTests.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.dashscope.api;
 
+import com.alibaba.cloud.ai.dashscope.rag.DashScopeStoreOptions;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeModel.ChatModel;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeModel.EmbeddingModel;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.EmbeddingRequest;
@@ -24,13 +25,23 @@ import com.alibaba.cloud.ai.dashscope.spec.DashScopeModel.EmbeddingTextType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.document.Document;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
 import java.util.List;
+import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 /**
  * Tests for DashScopeApi class functionality
@@ -65,6 +76,73 @@ class DashScopeApiTests {
 		assertEquals("qwen-plus", ChatModel.QWEN_PLUS.getValue(), "ChatModel.QWEN_PLUS should have value 'qwen-plus'");
 		assertEquals("qwen-turbo", ChatModel.QWEN_TURBO.getValue(),
 				"ChatModel.QWEN_TURBO should have value 'qwen-turbo'");
+	}
+
+	@Test
+	void upsertPipelineShouldIngestDocumentsWithoutCreatingPipelineWhenPipelineAlreadyExists() {
+		RestClient.Builder restClientBuilder = RestClient.builder();
+		MockRestServiceServer server = MockRestServiceServer.bindTo(restClientBuilder).build();
+		DashScopeApi api = DashScopeApi.builder()
+			.apiKey("test-api-key")
+			.restClientBuilder(restClientBuilder)
+			.build();
+		DashScopeStoreOptions options = new DashScopeStoreOptions("existing-index");
+
+		server.expect(once(),
+				requestTo("https://dashscope.aliyuncs.com/api/v1/indices/pipeline_simple?pipeline_name=existing-index"))
+			.andExpect(method(HttpMethod.GET))
+			.andRespond(withSuccess("""
+					{"id":"pipeline-1","status":"SUCCESS"}
+					""", MediaType.APPLICATION_JSON));
+		server.expect(once(), requestTo("https://dashscope.aliyuncs.com/api/v1/indices/pipeline/pipeline-1/managed_ingest"))
+			.andExpect(method(HttpMethod.POST))
+			.andRespond(withSuccess("""
+					{"ingestionId":"ingestion-1","code":"SUCCESS"}
+					""", MediaType.APPLICATION_JSON));
+
+		assertThatCode(() -> api.upsertPipeline(List.of(new Document("file-1", "content", Map.of())), options))
+			.doesNotThrowAnyException();
+
+		server.verify();
+	}
+
+	@Test
+	void upsertPipelineShouldFallbackToExistingPipelineWhenCreateFails() {
+		RestClient.Builder restClientBuilder = RestClient.builder();
+		MockRestServiceServer server = MockRestServiceServer.bindTo(restClientBuilder).build();
+		DashScopeApi api = DashScopeApi.builder()
+			.apiKey("test-api-key")
+			.restClientBuilder(restClientBuilder)
+			.build();
+		DashScopeStoreOptions options = new DashScopeStoreOptions("race-index");
+
+		server.expect(once(),
+				requestTo("https://dashscope.aliyuncs.com/api/v1/indices/pipeline_simple?pipeline_name=race-index"))
+			.andExpect(method(HttpMethod.GET))
+			.andRespond(withSuccess("""
+					{"status":"SUCCESS"}
+					""", MediaType.APPLICATION_JSON));
+		server.expect(once(), requestTo("https://dashscope.aliyuncs.com/api/v1/indices/pipeline"))
+			.andExpect(method(HttpMethod.PUT))
+			.andRespond(withSuccess("""
+					{"status":"FAILED","message":"duplicate pipeline"}
+					""", MediaType.APPLICATION_JSON));
+		server.expect(once(),
+				requestTo("https://dashscope.aliyuncs.com/api/v1/indices/pipeline_simple?pipeline_name=race-index"))
+			.andExpect(method(HttpMethod.GET))
+			.andRespond(withSuccess("""
+					{"id":"pipeline-1","status":"SUCCESS"}
+					""", MediaType.APPLICATION_JSON));
+		server.expect(once(), requestTo("https://dashscope.aliyuncs.com/api/v1/indices/pipeline/pipeline-1/managed_ingest"))
+			.andExpect(method(HttpMethod.POST))
+			.andRespond(withSuccess("""
+					{"ingestionId":"ingestion-2","code":"SUCCESS"}
+					""", MediaType.APPLICATION_JSON));
+
+		assertThatCode(() -> api.upsertPipeline(List.of(new Document("file-1", "content", Map.of())), options))
+			.doesNotThrowAnyException();
+
+		server.verify();
 	}
 
 	@Test


### PR DESCRIPTION
### Describe what this PR does / why we need it

`DashScopeCloudStore.add()` delegates document ingestion to `DashScopeApi.upsertPipeline(...)`. The previous implementation always tried to create a pipeline with `PUT /api/v1/indices/pipeline` before starting `managed_ingest`.

When the target pipeline already exists, the duplicate create request can fail before `POST /api/v1/indices/pipeline/{pipeline_id}/managed_ingest` is reached. As a result, subsequent `add(...)` calls cannot append documents to the existing pipeline.

This PR fixes that path by reusing an existing pipeline when possible and only creating a pipeline when it is missing.

### Does this pull request fix one issue?

Refs alibaba/spring-ai-alibaba#4766

### Describe how you did it

- Query `getPipelineIdByName(indexName)` before creating a pipeline.
- If a pipeline id already exists, call `managed_ingest` directly with the current document ids.
- If the pipeline does not exist, keep the existing create-then-ingest flow.
- If creation returns a non-success response, query the pipeline again as a concurrency/backward-compatibility fallback before throwing `CreateIndexError`.
- Add request-level tests for the existing-pipeline path and the create-failure fallback path.

### Describe how to verify it

```bash
mvn -pl models/dashscope -Dtest=DashScopeApiTests test
git diff --check
```

### Special notes for reviews

The change is intentionally scoped to the existing `DashScopeCloudStore.add()` ingestion path. It does not introduce the separate Bailian SDK add-document workflow.