### PR TITLE
fix(dashscope): reuse existing pipelines for ingest

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -67,6 +67,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.ADD_FILE_CATEGORY_RESTFUL_URL;
+import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.ADD_PIPELINE_DOCUMENTS_RESTFUL_URL;
 import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.DELETE_PIPELINE_RESTFUL_URL;
 import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.DOCUMENT_SPLITER_RESTFUL_URL;
 import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.DOWNLOAD_LEASE_CATEGORY_RESTFUL_URL;
@@ -416,6 +417,26 @@ public class DashScopeApi {
                 List.of(new DashScopeApiSpec.DataSinksConfig("BUILT_IN", null))
 
 		);
+		String pipelineId = getPipelineIdByName(storeOptions.getIndexName());
+		if (StringUtils.hasText(pipelineId)) {
+			addPipelineDocuments(pipelineId, upsertPipelineRequest);
+			return;
+		}
+		pipelineId = createPipeline(upsertPipelineRequest);
+		if (!StringUtils.hasText(pipelineId)) {
+			pipelineId = getPipelineIdByName(storeOptions.getIndexName());
+			if (StringUtils.hasText(pipelineId)) {
+				addPipelineDocuments(pipelineId, upsertPipelineRequest);
+				return;
+			}
+		}
+		if (!StringUtils.hasText(pipelineId)) {
+			throw new DashScopeException(ErrorCodeEnum.CREATE_INDEX_ERROR);
+		}
+		startManagedIngest(pipelineId, upsertPipelineRequest);
+	}
+
+	private String createPipeline(DashScopeApiSpec.UpsertPipelineRequest upsertPipelineRequest) {
 		ResponseEntity<DashScopeApiSpec.UpsertPipelineResponse> upsertPipelineResponse = this.restClient.put()
 			.uri(PIPELINE_RESTFUL_URL)
 			.body(upsertPipelineRequest)
@@ -423,9 +444,26 @@ public class DashScopeApi {
 			.toEntity(DashScopeApiSpec.UpsertPipelineResponse.class);
 		if (upsertPipelineResponse.getBody() == null
 				|| !"SUCCESS".equalsIgnoreCase(upsertPipelineResponse.getBody().status())) {
-			throw new DashScopeException(ErrorCodeEnum.CREATE_INDEX_ERROR);
+			return null;
 		}
-		String pipelineId = upsertPipelineResponse.getBody().id();
+		return upsertPipelineResponse.getBody().id();
+	}
+
+	private void addPipelineDocuments(String pipelineId, DashScopeApiSpec.UpsertPipelineRequest upsertPipelineRequest) {
+		DashScopeApiSpec.AddPipelineDocumentsRequest request = new DashScopeApiSpec.AddPipelineDocumentsRequest(
+				upsertPipelineRequest.transformations(), upsertPipelineRequest.dataSources());
+		ResponseEntity<DashScopeApiSpec.StartPipelineResponse> response = this.restClient.put()
+			.uri(ADD_PIPELINE_DOCUMENTS_RESTFUL_URL, pipelineId)
+			.body(request)
+			.retrieve()
+			.toEntity(DashScopeApiSpec.StartPipelineResponse.class);
+		if (response.getBody() == null || !"SUCCESS".equalsIgnoreCase(response.getBody().code())
+				|| response.getBody().ingestionId() == null) {
+			throw new DashScopeException(ErrorCodeEnum.INDEX_ADD_DOCUMENT_ERROR);
+		}
+	}
+
+	private void startManagedIngest(String pipelineId, DashScopeApiSpec.UpsertPipelineRequest upsertPipelineRequest) {
 		ResponseEntity<DashScopeApiSpec.StartPipelineResponse> startPipelineResponse = this.restClient.post()
 			.uri(MANAGED_INGEST_PIPELINE_RESTFUL_URL, pipelineId)
 			.body(upsertPipelineRequest)

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/common/DashScopeApiConstants.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/common/DashScopeApiConstants.java
@@ -88,6 +88,8 @@ public final class DashScopeApiConstants {
 
 	public static final String MANAGED_INGEST_PIPELINE_RESTFUL_URL = "/api/v1/indices/pipeline/{pipeline_id}/managed_ingest";
 
+	public static final String ADD_PIPELINE_DOCUMENTS_RESTFUL_URL = "/api/v1/indices/pipeline/{pipeline_id}/documents";
+
 	public static final String DELETE_PIPELINE_RESTFUL_URL = "/api/v1/indices/pipeline/{pipeline_id}/delete";
 
 	public static final String RETRIEVE_PIPELINE_RESTFUL_URL = "/api/v1/indices/pipeline/{pipeline_id}/retrieve";

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
@@ -350,6 +350,11 @@ public class DashScopeApiSpec {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record AddPipelineDocumentsRequest(@JsonProperty("configured_transformations") List transformations,
+                                              @JsonProperty("data_sources") List<DataSourcesConfig> dataSources) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public record DataSinksConfig(@JsonProperty("sink_type") String sinkType,
                                   @JsonProperty("component") DataSinksComponent component) {
 

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApiTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApiTests.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.dashscope.api;
 
+import com.alibaba.cloud.ai.dashscope.rag.DashScopeStoreOptions;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeModel.ChatModel;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeModel.EmbeddingModel;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.EmbeddingRequest;
@@ -24,13 +25,23 @@ import com.alibaba.cloud.ai.dashscope.spec.DashScopeModel.EmbeddingTextType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.document.Document;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
 import java.util.List;
+import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 /**
  * Tests for DashScopeApi class functionality
@@ -65,6 +76,73 @@ class DashScopeApiTests {
 		assertEquals("qwen-plus", ChatModel.QWEN_PLUS.getValue(), "ChatModel.QWEN_PLUS should have value 'qwen-plus'");
 		assertEquals("qwen-turbo", ChatModel.QWEN_TURBO.getValue(),
 				"ChatModel.QWEN_TURBO should have value 'qwen-turbo'");
+	}
+
+	@Test
+	void upsertPipelineShouldAddDocumentsWithoutCreatingPipelineWhenPipelineAlreadyExists() {
+		RestClient.Builder restClientBuilder = RestClient.builder();
+		MockRestServiceServer server = MockRestServiceServer.bindTo(restClientBuilder).build();
+		DashScopeApi api = DashScopeApi.builder()
+			.apiKey("test-api-key")
+			.restClientBuilder(restClientBuilder)
+			.build();
+		DashScopeStoreOptions options = new DashScopeStoreOptions("existing-index");
+
+		server.expect(once(),
+				requestTo("https://dashscope.aliyuncs.com/api/v1/indices/pipeline_simple?pipeline_name=existing-index"))
+			.andExpect(method(HttpMethod.GET))
+			.andRespond(withSuccess("""
+					{"id":"pipeline-1","status":"SUCCESS"}
+					""", MediaType.APPLICATION_JSON));
+		server.expect(once(), requestTo("https://dashscope.aliyuncs.com/api/v1/indices/pipeline/pipeline-1/documents"))
+			.andExpect(method(HttpMethod.PUT))
+			.andRespond(withSuccess("""
+					{"ingestionId":"ingestion-1","code":"SUCCESS"}
+					""", MediaType.APPLICATION_JSON));
+
+		assertThatCode(() -> api.upsertPipeline(List.of(new Document("file-1", "content", Map.of())), options))
+			.doesNotThrowAnyException();
+
+		server.verify();
+	}
+
+	@Test
+	void upsertPipelineShouldFallbackToExistingPipelineWhenCreateFails() {
+		RestClient.Builder restClientBuilder = RestClient.builder();
+		MockRestServiceServer server = MockRestServiceServer.bindTo(restClientBuilder).build();
+		DashScopeApi api = DashScopeApi.builder()
+			.apiKey("test-api-key")
+			.restClientBuilder(restClientBuilder)
+			.build();
+		DashScopeStoreOptions options = new DashScopeStoreOptions("race-index");
+
+		server.expect(once(),
+				requestTo("https://dashscope.aliyuncs.com/api/v1/indices/pipeline_simple?pipeline_name=race-index"))
+			.andExpect(method(HttpMethod.GET))
+			.andRespond(withSuccess("""
+					{"status":"SUCCESS"}
+					""", MediaType.APPLICATION_JSON));
+		server.expect(once(), requestTo("https://dashscope.aliyuncs.com/api/v1/indices/pipeline"))
+			.andExpect(method(HttpMethod.PUT))
+			.andRespond(withSuccess("""
+					{"status":"FAILED","message":"duplicate pipeline"}
+					""", MediaType.APPLICATION_JSON));
+		server.expect(once(),
+				requestTo("https://dashscope.aliyuncs.com/api/v1/indices/pipeline_simple?pipeline_name=race-index"))
+			.andExpect(method(HttpMethod.GET))
+			.andRespond(withSuccess("""
+					{"id":"pipeline-1","status":"SUCCESS"}
+					""", MediaType.APPLICATION_JSON));
+		server.expect(once(), requestTo("https://dashscope.aliyuncs.com/api/v1/indices/pipeline/pipeline-1/documents"))
+			.andExpect(method(HttpMethod.PUT))
+			.andRespond(withSuccess("""
+					{"ingestionId":"ingestion-2","code":"SUCCESS"}
+					""", MediaType.APPLICATION_JSON));
+
+		assertThatCode(() -> api.upsertPipeline(List.of(new Document("file-1", "content", Map.of())), options))
+			.doesNotThrowAnyException();
+
+		server.verify();
 	}
 
 	@Test


### PR DESCRIPTION
### 这个 PR 做了什么 / 为什么需要它

这个 PR 修复 `DashScopeCloudStore.add()` 向已存在的 DashScope/Bailian pipeline 继续追加文档时，文件上传和解析成功、`add()` 也可能收到成功响应，但百炼后台知识库文档列表没有增加的问题。

关联 issue：alibaba/spring-ai-alibaba#4766

### 根因追踪

完整链路如下：

```text
DashScopeDocumentCloudReader.get()
  -> upload file / add_file / parse success
  -> 返回 Document(id = data center file_id)

DashScopeCloudStore.add(documents)
  -> DashScopeApi.upsertPipeline(documents, options)
```

旧实现会把“创建 pipeline”和“追加文档”混在 `upsertPipeline(...)` 中：

```text
PUT  /api/v1/indices/pipeline
POST /api/v1/indices/pipeline/{pipeline_id}/managed_ingest
```

第一次调用时，pipeline 不存在，创建并首次入库可以成功；第二次开始，同名 pipeline 已存在，重复创建会触发 `PipelineNameAlreadyExists`。

进一步真实验证发现：仅绕开重复创建、改为对已有 pipeline 调用 `POST /managed_ingest` 仍然不够。`managed_ingest` 会返回同步成功和 `ingestionId`，但查询该异步任务状态得到：

```text
ingestion_status=COMPLETED
total_count=0
rows=[]
```

也就是说任务完成了，但实际处理了 0 个文档，百炼后台文档列表不会增加。这也解释了 issue 中反馈的“收到 200、拿到新上传 id，但后台知识库没有新增文档”。

参考 DashScope managed index 的已有集成实现，已有 pipeline 追加文档使用的是：

```text
PUT /api/v1/indices/pipeline/{pipeline_id}/documents
```

而不是再次调用 `managed_ingest`。

参考：

- https://github.com/run-llama/llama_index/blob/main/llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/constants.py
- https://docs.llamaindex.ai/en/stable/api_reference/indices/dashscope/

### 修复方案

`DashScopeApi.upsertPipeline(...)` 现在按 pipeline 是否存在分流：

1. 先通过 `getPipelineIdByName(indexName)` 查询 pipeline。
2. 如果 pipeline 已存在，调用：

```text
PUT /api/v1/indices/pipeline/{pipeline_id}/documents
```

请求体只携带追加文档需要的：

```text
configured_transformations
data_sources
```

3. 如果 pipeline 不存在，保留首次创建流程：

```text
PUT  /api/v1/indices/pipeline
POST /api/v1/indices/pipeline/{pipeline_id}/managed_ingest
```

4. 如果创建 pipeline 返回非 `SUCCESS`，再查询一次 pipeline 作为并发/历史兼容兜底；如果这时查到 pipeline，则走 `PUT /documents` 追加文档。

### 代码改动

- 新增 `ADD_PIPELINE_DOCUMENTS_RESTFUL_URL` 常量。
- 新增 `DashScopeApiSpec.AddPipelineDocumentsRequest`，用于已有 pipeline 的增量追加请求体。
- 调整 `DashScopeApi.upsertPipeline(...)`：
  - 已有 pipeline：`PUT /documents`。
  - 新 pipeline：创建后保留 `POST /managed_ingest` 首次构建。
  - 创建竞态兜底：查到已有 pipeline 后 `PUT /documents`。
- 更新 `DashScopeApiTests`，避免再次把已有 pipeline 场景测试成 `managed_ingest`。

### 验证

本地单测：

```bash
mvn -pl models/dashscope -Dtest=DashScopeApiTests test
git diff --check
```

结果：

```text
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
```

真实百炼测试知识库验证：

1. 未修复链路第二次上传/解析成功，但重复 `PUT /pipeline` 返回 `PipelineNameAlreadyExists`。
2. 旧修复方向中，已有 pipeline 调 `POST /managed_ingest` 返回成功，但任务状态为 `COMPLETED,total_count=0,rows=[]`，文档列表不增加。
3. 同一个未入库文件改用 `PUT /pipeline/{pipeline_id}/documents` 后，百炼 `ListIndexDocuments` 返回目标文件 `FINISH / 索引构建成功`。
4. 使用本 PR 最新代码重新跑 `DashScopeCloudStore.add()`，新文件成功出现在百炼文档列表中：`FINISH / 索引构建成功`。

### PR 历史说明

此前 #285 已关闭，本 PR (#286) 替代 #285。#286 已从最初“复用 pipeline 后继续 managed_ingest”的方案更新为最终可闭环的 `PUT /documents` 增量追加方案。