### PR TITLE
Fix chat model video media content handling

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -96,6 +96,7 @@ import java.util.stream.IntStream;
  *
  * @author yuluo
  * @author <a href="mailto:yuluo08290126@gmail.com">yuluo</a>
+ * @author xuguan
  * @see ChatModel
  */
 public class DashScopeChatModel implements ChatModel {
@@ -640,47 +641,41 @@ public class DashScopeChatModel implements ChatModel {
 	}
 
 	private List<MediaContent> convertMediaContent(UserMessage message, Map<String, String> cacheControl) {
-		MessageFormat format = MessageFormat.IMAGE;
-		if (message.getMetadata().get(DashScopeApiConstants.MESSAGE_FORMAT) instanceof MessageFormat messageFormat) {
-			format = messageFormat;
-		}
-
 		List<MediaContent> contentList = new ArrayList<>();
-		if (format == MessageFormat.VIDEO) {
-			List<String> mediaList = message.getMedia()
-				.stream()
-				.map(media -> this.fromMediaData(media.getMimeType(), media.getData()))
-				.toList();
+		for (var media : message.getMedia()) {
+			MessageFormat format = null;
+			if (message.getMetadata().get(DashScopeApiConstants.MESSAGE_FORMAT) instanceof MessageFormat messageFormat) {
+				format = messageFormat;
+			}
+			if (format == null) {
+				break;
+			}
 
-			contentList.add(new MediaContent("video", null, null, mediaList));
-
-			// Apply cache_control to the text content (last content part)
-			MediaContent mediaContent = new MediaContent(message.getText(), cacheControl);
-			contentList.add(mediaContent);
-		}
-		else if (format == MessageFormat.AUDIO) {
-			contentList.addAll(message.getMedia()
-				.stream()
-				.map(media -> new MediaContent("audio", null, null, null,
-						this.fromMediaData(media.getMimeType(), media.getData())))
-				.toList());
-
-			// Apply cache_control to the text content (last content part)
-			MediaContent mediaContent = new MediaContent(message.getText(), cacheControl);
-			contentList.add(mediaContent);
-		}
-		else {
-			contentList.addAll(message.getMedia()
-				.stream()
-				.map(media -> new MediaContent("image", null, this.fromMediaData(media.getMimeType(), media.getData()),
-						null))
-				.toList());
-
-			// Apply cache_control to the text content (last content part)
-			MediaContent mediaContent = new MediaContent(message.getText(), cacheControl);
-			contentList.add(mediaContent);
+			if (format == MessageFormat.IMAGE) {
+				contentList.add(new MediaContent("image", null, this.fromMediaData(media.getMimeType(), media.getData()), null));
+			}
+			else if (format == MessageFormat.VIDEO) {
+                String mimeType = media.getMimeType().toString();
+                // Image list
+                if (mimeType.startsWith("image/")) {
+                    contentList.add(new MediaContent("video", null, null, List.of(this.fromMediaData(media.getMimeType(), media.getData()))));
+                }
+                // Video
+                else {
+                    contentList.add(new MediaContent("video", null, null, this.fromMediaData(media.getMimeType(), media.getData())));
+                }
+			}
+			else if (format == MessageFormat.AUDIO) {
+				contentList.add(new MediaContent("audio", null, null, null, this.fromMediaData(media.getMimeType(), media.getData())));
+			}
+			else {
+                // Default to text
+				contentList.add(new MediaContent(this.fromMediaData(media.getMimeType(), media.getData()), cacheControl));
+			}
 		}
 
+		// Apply cache_control to the text content (last content part)
+        contentList.add(new MediaContent(message.getText(), cacheControl));
 		return contentList;
 	}
 

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -647,9 +647,6 @@ public class DashScopeChatModel implements ChatModel {
 			if (message.getMetadata().get(DashScopeApiConstants.MESSAGE_FORMAT) instanceof MessageFormat messageFormat) {
 				format = messageFormat;
 			}
-			if (format == null) {
-				break;
-			}
 
 			if (format == MessageFormat.IMAGE) {
 				contentList.add(new MediaContent("image", null, this.fromMediaData(media.getMimeType(), media.getData()), null));

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.model.ModelOptionsUtils;
 /**
- * @author yuluo, yingzi
+ * @author yuluo, yingzi, xuguan
  */
 
 public class DashScopeApiSpec {
@@ -984,8 +984,8 @@ public class DashScopeApiSpec {
          * When set to {"type": "ephemeral"}, the system will attempt to hit or create a cache.
          */
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        public record MediaContent(@JsonProperty("type") String type, @JsonProperty("text") String text,
-                                   @JsonProperty("image") String image, @JsonProperty("video") List<String> video,
+        public record MediaContent(@JsonIgnore @JsonProperty("type") String type, @JsonProperty("text") String text,
+                                   @JsonProperty("image") String image, @JsonProperty("video") Object video,
                                    @JsonProperty("audio") String audio,
                                    @JsonProperty("cache_control") Map<String, String> cacheControl) {
             /**
@@ -1005,11 +1005,11 @@ public class DashScopeApiSpec {
                 this("text", text, null, null, null, cacheControl);
             }
 
-            public MediaContent(String type, String text, String image, List<String> video) {
+            public MediaContent(String type, String text, String image, Object video) {
                 this(type, text, image, video, null, null);
             }
 
-            public MediaContent(String type, String text, String image, List<String> video, String audio) {
+            public MediaContent(String type, String text, String image, Object video, String audio) {
                 this(type, text, image, video, audio, null);
             }
         }

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatIT.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatIT.java
@@ -15,9 +15,11 @@
  */
 package com.alibaba.cloud.ai.dashscope.chat;
 
+import java.net.URI;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 
 import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
 import org.junit.jupiter.api.Assumptions;
@@ -29,6 +31,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
 import org.springframework.ai.support.ToolCallbacks;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -42,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * AI_DASHSCOPE_API_KEY environment variable is set.
  *
  * @author brianxiadong
+ * @author xuguan
  * @since 1.0.0-M5.1
  */
 @Tag("integration")
@@ -157,6 +161,39 @@ class DashScopeChatIT {
         assertThat(result).containsIgnoringCase("time");
         assertThat(result).containsIgnoringCase("alarm");
         assertThat(result).containsIgnoringCase("weather");
+    }
+
+    @Test
+    void testVideoMediaVisionChat() {
+        // Create real API client with API key from environment
+        DashScopeApi realApi = DashScopeApi.builder().apiKey(apiKey).build();
+
+        // Create chat model with default options
+        DashScopeChatOptions options = DashScopeChatOptions.builder().model("qwen3-vl-flash").multiModel(true).build();
+
+        DashScopeChatModel chatModel = DashScopeChatModel.builder()
+                .dashScopeApi(realApi)
+                .defaultOptions(options)
+                .build();
+
+        // Create prompt with user message
+        Media media = Media.builder()
+                .mimeType(Media.Format.VIDEO_MP4)
+                .data(URI.create("https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20241115/cqqkru/1.mp4"))
+                .build();
+        UserMessage userMessage = UserMessage
+                .builder()
+                .text("视频里的内容是什么?")
+                .media(media)
+                .metadata(Map.of("messageFormat", MessageFormat.VIDEO))
+                .build();
+        Prompt prompt = Prompt.builder().messages(userMessage).build();
+
+        // Call the chat model
+        Generation response = chatModel.call(prompt).getResult();
+
+        String text = response.getOutput().getText();
+        System.out.println("Chat Response Text: " + text);
     }
 
     static class DateTimeTools {


### PR DESCRIPTION
### Describe what this PR does / why we need it

The chat model's video media handling is wrong. Video content should be typed as `String` and image lists as `List`, rather than always using `List`.

When I use a video media. It cause a Exception as follow.
```java
org.springframework.ai.retry.NonTransientAiException: 400 - {"request_id":"d628a1e4-ed8c-935b-9478-d357c9bb495e","code":"InvalidParameter","message":"<400> InternalError.Algo.InvalidParameter: The video modality input does not meet the requirements because: the range of sequence images should be (4, 2000)."}
```

### Special note
When the `MessageFormat` is missed. Use `MessageFormat.IMAGE` as default previous, but it will be treat as text now.