### PR TITLE
fix(dashscope): send delete-document `component` as object not array

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -478,7 +478,7 @@ public class DashScopeApi {
 	public boolean deletePipelineDocument(String pipelineId, List<String> idList) {
 		DashScopeApiSpec.DelePipelineDocumentRequest request = new DashScopeApiSpec.DelePipelineDocumentRequest(Arrays
 			.asList(new DashScopeApiSpec.DelePipelineDocumentRequest.DelePipelineDocumentDataSource("DATA_CENTER_FILE",
-					Arrays.asList(new DashScopeApiSpec.DelePipelineDocumentRequest.DelePipelineDocumentDataSourceComponent(idList)))));
+					new DashScopeApiSpec.DelePipelineDocumentRequest.DelePipelineDocumentDataSourceComponent(idList))));
 		ResponseEntity<DashScopeApiSpec.DelePipelineDocumentResponse> deleDocumentResponse = this.restClient.post()
 			.uri(DELETE_PIPELINE_RESTFUL_URL, pipelineId)
 			.body(request)

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
@@ -441,7 +441,7 @@ public class DashScopeApiSpec {
             @JsonProperty("data_sources") List<DelePipelineDocumentDataSource> dataSources) {
         @JsonInclude(JsonInclude.Include.NON_NULL)
         public record DelePipelineDocumentDataSource(@JsonProperty("source_type") String sourceType,
-                                                     @JsonProperty("component") List<DelePipelineDocumentDataSourceComponent> component) {
+                                                     @JsonProperty("component") DelePipelineDocumentDataSourceComponent component) {
         }
 
         @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApiTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApiTests.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
@@ -142,6 +143,34 @@ class DashScopeApiTests {
 		assertThatCode(() -> api.upsertPipeline(List.of(new Document("file-1", "content", Map.of())), options))
 			.doesNotThrowAnyException();
 
+		server.verify();
+	}
+
+	// The DATA_CENTER_FILE data source expects `component` to be a single object (as the
+	// add/upsert path already sends). Wrapping it in an array made the delete request body
+	// malformed and DashScope answered 500 SystemError (gh#288). Assert `component` is an
+	// object whose `doc_ids` are directly addressable; the old array shape fails this.
+	@Test
+	void deletePipelineDocumentShouldSendComponentAsObjectNotArray() {
+		RestClient.Builder restClientBuilder = RestClient.builder();
+		MockRestServiceServer server = MockRestServiceServer.bindTo(restClientBuilder).build();
+		DashScopeApi api = DashScopeApi.builder()
+			.apiKey("test-api-key")
+			.restClientBuilder(restClientBuilder)
+			.build();
+
+		server.expect(once(), requestTo("https://dashscope.aliyuncs.com/api/v1/indices/pipeline/pipeline-1/delete"))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(jsonPath("$.data_sources[0].source_type").value("DATA_CENTER_FILE"))
+			.andExpect(jsonPath("$.data_sources[0].component.doc_ids[0]").value("doc-1"))
+			.andExpect(jsonPath("$.data_sources[0].component.doc_ids[1]").value("doc-2"))
+			.andRespond(withSuccess("""
+					{"status":"200","code":"SUCCESS"}
+					""", MediaType.APPLICATION_JSON));
+
+		boolean deleted = api.deletePipelineDocument("pipeline-1", List.of("doc-1", "doc-2"));
+
+		assertEquals(true, deleted);
 		server.verify();
 	}
 


### PR DESCRIPTION
Closes #288

## Root cause

`DashScopeCloudStore#delete` → `DashScopeApi.deletePipelineDocument()` builds the `DATA_CENTER_FILE` data source with `component` wrapped in a `List`, so the request body serializes to:

```json
{"data_sources":[{"source_type":"DATA_CENTER_FILE","component":[{"doc_ids":[...]}]}]}
```

But the add/upsert path (`DataSourcesConfig`) sends `component` as a single **object**, which is what the pipeline API expects:

```json
{"data_sources":[{"source_type":"DATA_CENTER_FILE","component":{"doc_ids":[...]}}]}
```

So only the delete request was malformed (array where an object is expected), and DashScope answered a generic `500 SystemError`.

This is corroborated three ways:
- the frameworks own **add/upsert** path already sends `component` as an object and works;
- the upstream reference implementation this code was ported from (llama-index `llama-index-indices-managed-dashscope`, `api_utils.py`) sends `component` as an object for **both** insert and delete;
- the closely related main-repo issue alibaba/spring-ai-alibaba#2402, where the Bailian ticket engineer replied it was a parameter error ("参数传错了").

## Prior art / why it regressed

This exact fix was already merged as alibaba/spring-ai-alibaba#2531 ("fix(core): fix the dashscope cloud store delete", merged 2025-10-13, closing #2402) in the old `spring-ai-alibaba-core` module — the identical `List<..Component>` → single `..Component` + drop `Arrays.asList` change. When the DashScope code was migrated into this extensions repo, the pre-fix (array) version was carried over, so the fix was lost and the bug regressed. This PR re-applies it.

## Fix

- Type `DelePipelineDocumentDataSource.component` as a single `DelePipelineDocumentDataSourceComponent` (symmetric with `DataSourcesConfig.component`).
- Drop the `Arrays.asList(...)` wrapper in `deletePipelineDocument()`.

## Test

Added `DashScopeApiTests#deletePipelineDocumentShouldSendComponentAsObjectNotArray` (uses `MockRestServiceServer`, no API key): asserts the delete request body carries `component` as an object whose `doc_ids` are directly addressable. Verified it **fails on the pre-fix code** (component was an array) and passes after. Existing `DashScopeApiTests` / `DashScopeCloudStoreTests` all green.

> Note: I do not have a Bailian account to verify live end-to-end; the fix mirrors the already-merged #2531 and the upstream llama-index request shape.