### PR TITLE
feat(mcp-gateway): make gateway tool call timeout configurable

### DIFF
--- a/mcp/spring-ai-alibaba-mcp-gateway/src/main/java/com/alibaba/cloud/ai/mcp/gateway/core/McpGatewayProperties.java
+++ b/mcp/spring-ai-alibaba-mcp-gateway/src/main/java/com/alibaba/cloud/ai/mcp/gateway/core/McpGatewayProperties.java
@@ -61,6 +61,12 @@ public class McpGatewayProperties {
 
 	private StreamableConfig streamable = new StreamableConfig();
 
+	/**
+	 * Timeout for a single outbound gateway tool call. Some proxied tool endpoints may take
+	 * longer than the default to respond, so this is configurable. Defaults to 30 seconds.
+	 */
+	private Duration toolTimeout = Duration.ofSeconds(30);
+
 	public static class SseConfig {
 
 		private Boolean enabled = true; // 默认启用，保持向后兼容
@@ -203,6 +209,14 @@ public class McpGatewayProperties {
 
 	public void setWebclientConnectorProtocol(String webclientConnectorProtocol) {
 		this.webclientConnectorProtocol = webclientConnectorProtocol;
+	}
+
+	public Duration getToolTimeout() {
+		return toolTimeout;
+	}
+
+	public void setToolTimeout(Duration toolTimeout) {
+		this.toolTimeout = toolTimeout;
 	}
 
 }

--- a/mcp/spring-ai-alibaba-mcp-gateway/src/main/java/com/alibaba/cloud/ai/mcp/gateway/nacos/callback/NacosMcpGatewayToolCallback.java
+++ b/mcp/spring-ai-alibaba-mcp-gateway/src/main/java/com/alibaba/cloud/ai/mcp/gateway/nacos/callback/NacosMcpGatewayToolCallback.java
@@ -855,8 +855,9 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
                 logger.info("[handleMcpStreamProtocol] Using HttpClientSseClientTransport for mcp-sse");
             }
 
-            // Create MCP sync client
-            McpSyncClient client = McpClient.sync(transport).build();
+            // Create MCP sync client with the configured request timeout so slow
+            // proxied MCP tools honor spring.ai.alibaba.mcp.gateway.tool-timeout too
+            McpSyncClient client = McpClient.sync(transport).requestTimeout(getTimeoutDuration()).build();
 
             try {
                 // Initialize client
@@ -902,7 +903,15 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
     }
 
     private Duration getTimeoutDuration() {
-
+        try {
+            McpGatewayProperties gatewayProperties = SpringBeanUtils.getInstance().getBean(McpGatewayProperties.class);
+            if (gatewayProperties != null && gatewayProperties.getToolTimeout() != null) {
+                return gatewayProperties.getToolTimeout();
+            }
+        } catch (Exception ex) {
+            logger.debug("Unable to obtain McpGatewayProperties; using default tool timeout for tool '{}'",
+                    this.toolDefinition.name(), ex);
+        }
         return Duration.ofSeconds(30); // Default timeout
     }
 

--- a/mcp/spring-ai-alibaba-mcp-gateway/src/test/java/com/alibaba/cloud/ai/mcp/gateway/nacos/callback/NacosMcpGatewayToolCallbackTest.java
+++ b/mcp/spring-ai-alibaba-mcp-gateway/src/test/java/com/alibaba/cloud/ai/mcp/gateway/nacos/callback/NacosMcpGatewayToolCallbackTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.cloud.ai.mcp.gateway.nacos.callback;
 
+import com.alibaba.cloud.ai.mcp.gateway.core.McpGatewayProperties;
 import com.alibaba.cloud.ai.mcp.gateway.core.utils.SpringBeanUtils;
 import com.alibaba.cloud.ai.mcp.gateway.nacos.definition.NacosMcpGatewayToolDefinition;
 import com.alibaba.cloud.ai.mcp.nacos.service.NacosMcpOperationService;
@@ -31,6 +32,7 @@ import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
@@ -86,6 +88,40 @@ class NacosMcpGatewayToolCallbackTest {
 		String result = (String) processResponse.invoke(callback, response, templateNode, Collections.emptyMap());
 
 		assertEquals(response, result);
+	}
+
+	@Test
+	void getTimeoutDurationReadsConfiguredValue() throws Exception {
+		McpGatewayProperties properties = new McpGatewayProperties();
+		properties.setToolTimeout(Duration.ofSeconds(60));
+		applicationContext.getBeanFactory().registerSingleton("mcpGatewayProperties", properties);
+
+		Duration timeout = invokeGetTimeoutDuration();
+
+		assertEquals(Duration.ofSeconds(60), timeout);
+	}
+
+	@Test
+	void getTimeoutDurationFallsBackToDefaultWhenNoPropertiesBean() throws Exception {
+		// setUp() registers no McpGatewayProperties bean, so the lookup fails and the
+		// default 30s timeout is used.
+		Duration timeout = invokeGetTimeoutDuration();
+
+		assertEquals(Duration.ofSeconds(30), timeout);
+	}
+
+	private Duration invokeGetTimeoutDuration() throws Exception {
+		NacosMcpGatewayToolDefinition definition = new NacosMcpGatewayToolDefinition();
+		definition.setName("test-tool");
+		definition.setDescription("test tool");
+		definition.setProtocol("http");
+		definition.setRemoteServerConfig(new McpServerRemoteServiceConfig());
+
+		NacosMcpGatewayToolCallback callback = new NacosMcpGatewayToolCallback(definition);
+
+		Method getTimeoutDuration = NacosMcpGatewayToolCallback.class.getDeclaredMethod("getTimeoutDuration");
+		getTimeoutDuration.setAccessible(true);
+		return (Duration) getTimeoutDuration.invoke(callback);
 	}
 
 }


### PR DESCRIPTION
Closes #4782

## Problem

`NacosMcpGatewayToolCallback#getTimeoutDuration()` returned a hardcoded `Duration.ofSeconds(30)`. Proxied tool endpoints whose response takes longer than 30s always time out, with no way to raise the limit (as requested in #4782).

## Change

- Add a `toolTimeout` property (`Duration`, default `30s`) to `McpGatewayProperties` → config key `spring.ai.alibaba.mcp.gateway.tool-timeout`.
- `getTimeoutDuration()` now reads it via `SpringBeanUtils`, mirroring the existing graceful-degradation lookup already used for the WebClient connector settings: if the properties bean is unavailable or the value is `null`, it falls back to the 30s default.

Backward compatible — behaviour is unchanged unless the new property is set.

## Test

Added to `NacosMcpGatewayToolCallbackTest`:
- `getTimeoutDurationReadsConfiguredValue` — registers a `McpGatewayProperties` with `toolTimeout=60s` and asserts `getTimeoutDuration()` returns 60s (verified it **fails on the pre-fix code**, which returned 30s).
- `getTimeoutDurationFallsBackToDefaultWhenNoPropertiesBean` — asserts the 30s default when no properties bean is present.

Full `spring-ai-alibaba-mcp-gateway` module test suite green; spotless applied.