### PR TITLE
feat(dashscope): support video fps option for chat model

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -514,7 +514,8 @@ public class DashScopeChatModel implements ChatModel {
 
 				if (message instanceof UserMessage userMessage) {
 					if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
-						content = convertMediaContent(userMessage, cacheControl);
+						content = convertMediaContent(userMessage, cacheControl,
+								resolveVideoFps(userMessage, prompt.getOptions()));
 					}
 					else if (cacheControl != null) {
 						// Convert text to MediaContent with cache_control
@@ -641,7 +642,32 @@ public class DashScopeChatModel implements ChatModel {
 		return null;
 	}
 
-	private List<MediaContent> convertMediaContent(UserMessage message, Map<String, String> cacheControl) {
+	/**
+	 * Resolve the video fps for a user message. Message metadata
+	 * {@link DashScopeApiConstants#VIDEO_FPS} takes precedence over
+	 * {@link DashScopeChatOptions#getFps()}. Returns null when neither is set,
+	 * leaving the fps unset so DashScope applies its server-side default.
+	 */
+	private Double resolveVideoFps(UserMessage message, ChatOptions options) {
+		Object metadataFps = message.getMetadata().get(DashScopeApiConstants.VIDEO_FPS);
+		if (metadataFps instanceof Number num) {
+			return num.doubleValue();
+		}
+		if (metadataFps instanceof String str) {
+			try {
+				return Double.parseDouble(str.trim());
+			}
+			catch (NumberFormatException e) {
+				logger.warn("DashScopeChatModel resolveVideoFps Invalid videoFps format in message metadata");
+			}
+		}
+		if (options instanceof DashScopeChatOptions dashScopeOptions) {
+			return dashScopeOptions.getFps();
+		}
+		return null;
+	}
+
+	private List<MediaContent> convertMediaContent(UserMessage message, Map<String, String> cacheControl, Double fps) {
         Assert.hasText(message.getText(), "User message text must not be empty");
         List<MediaContent> contentList = new ArrayList<>();
         MessageFormat format = null;
@@ -664,11 +690,12 @@ public class DashScopeChatModel implements ChatModel {
                 }
                 // Video
                 else {
-                    contentList.add(new MediaContent("video", null, null, this.fromMediaData(media.getMimeType(), media.getData())));
+                    contentList.add(new MediaContent("video", null, null,
+                            this.fromMediaData(media.getMimeType(), media.getData()), null, fps));
                 }
             }
             if (!imageList.isEmpty()) {
-                contentList.add(new MediaContent("video", null, null, imageList));
+                contentList.add(new MediaContent("video", null, null, imageList, null, fps));
             }
         }
         else if (format == MessageFormat.AUDIO) {

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
@@ -319,6 +319,16 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
      */
     private @JsonProperty("extra_body") Map<String, Object> extraBody;
 
+    /**
+     * Frame extraction rate for video inputs. Sent as the {@code fps} attribute of
+     * video content items. Applies to both single video files (controls frame
+     * extraction frequency) and image frame lists (tells the model the extraction
+     * interval). Can be overridden per message via the
+     * {@link com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants#VIDEO_FPS}
+     * message metadata key.
+     */
+    private @JsonProperty("fps") Double fps;
+
     public DashScopeApiSpec.TranslationOptions getTranslationOptions() {
         return translationOptions;
     }
@@ -669,6 +679,14 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
         this.extraBody = extraBody;
     }
 
+    public Double getFps() {
+        return this.fps;
+    }
+
+    public void setFps(Double fps) {
+        this.fps = fps;
+    }
+
     public static DashScopeChatOptionsBuilder builder() {
         return new DashScopeChatOptionsBuilder();
     }
@@ -979,6 +997,11 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
             return this;
         }
 
+        public DashScopeChatOptionsBuilder fps(Double fps) {
+            this.options.fps = fps;
+            return this;
+        }
+
         public DashScopeChatOptions build() {
             return this.options;
         }
@@ -1016,6 +1039,7 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
                 .audio(fromOptions.audio)
                 .streamOptions(fromOptions.streamOptions)
                 .extraBody(fromOptions.extraBody)
+                .fps(fromOptions.fps)
                 .build();
     }
 
@@ -1048,7 +1072,8 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
                 && Objects.equals(this.toolContext, that.toolContext)
                 && Objects.equals(this.modalities, that.modalities) && Objects.equals(this.audio, that.audio)
                 && Objects.equals(this.streamOptions, that.streamOptions)
-                && Objects.equals(this.extraBody, that.extraBody);
+                && Objects.equals(this.extraBody, that.extraBody)
+                && Objects.equals(this.fps, that.fps);
     }
 
     @Override
@@ -1058,7 +1083,7 @@ public class DashScopeChatOptions implements ToolCallingChatOptions {
                 this.repetitionPenalty, this.tools, this.toolChoice, this.vlHighResolutionImages, this.enableThinking,
                 this.thinkingBudget, this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled,
                 this.multiModel, this.searchOptions, this.parallelToolCalls, this.httpHeaders, this.toolContext,
-                this.modalities, this.audio, this.streamOptions, this.extraBody);
+                this.modalities, this.audio, this.streamOptions, this.extraBody, this.fps);
     }
 
     @Override

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/common/DashScopeApiConstants.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/common/DashScopeApiConstants.java
@@ -112,6 +112,8 @@ public final class DashScopeApiConstants {
 
 	public static final String MESSAGE_FORMAT = "messageFormat";
 
+	public static final String VIDEO_FPS = "videoFps";
+
 	/**
 	 * Metadata key for cache control. When set to a Map containing {"type": "ephemeral"},
 	 * the system will create or hit an explicit cache for the message content.

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
@@ -1022,6 +1022,14 @@ public class DashScopeApiSpec {
             public MediaContent(String type, String text, String image, Object video, String audio, Double fps) {
                 this(type, text, image, video, audio, fps, null);
             }
+
+            /**
+             * Constructor kept for binary compatibility with the pre-fps signature.
+             */
+            public MediaContent(String type, String text, String image, Object video, String audio,
+                                Map<String, String> cacheControl) {
+                this(type, text, image, video, audio, null, cacheControl);
+            }
         }
 
         /**

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpec.java
@@ -985,20 +985,21 @@ public class DashScopeApiSpec {
          * @param video The image list of video. by adding multiple image_url content
          * parts. Image input is only supported when using the glm-4v model.
          * @param audio The audio content of the message.
+         * @param fps The frame extraction rate for video content.
          * @param cacheControl The cache control settings for explicit caching.
          * When set to {"type": "ephemeral"}, the system will attempt to hit or create a cache.
          */
         @JsonInclude(JsonInclude.Include.NON_NULL)
         public record MediaContent(@JsonIgnore @JsonProperty("type") String type, @JsonProperty("text") String text,
                                    @JsonProperty("image") String image, @JsonProperty("video") Object video,
-                                   @JsonProperty("audio") String audio,
+                                   @JsonProperty("audio") String audio, @JsonProperty("fps") Double fps,
                                    @JsonProperty("cache_control") Map<String, String> cacheControl) {
             /**
              * Shortcut constructor for a text content.
              * @param text The text content of the message.
              */
             public MediaContent(String text) {
-                this("text", text, null, null, null, null);
+                this("text", text, null, null, null, null, null);
             }
 
             /**
@@ -1007,15 +1008,19 @@ public class DashScopeApiSpec {
              * @param cacheControl The cache control settings.
              */
             public MediaContent(String text, Map<String, String> cacheControl) {
-                this("text", text, null, null, null, cacheControl);
+                this("text", text, null, null, null, null, cacheControl);
             }
 
             public MediaContent(String type, String text, String image, Object video) {
-                this(type, text, image, video, null, null);
+                this(type, text, image, video, null, null, null);
             }
 
             public MediaContent(String type, String text, String image, Object video, String audio) {
-                this(type, text, image, video, audio, null);
+                this(type, text, image, video, audio, null, null);
+            }
+
+            public MediaContent(String type, String text, String image, Object video, String audio, Double fps) {
+                this(type, text, image, video, audio, fps, null);
             }
         }
 

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeMultiModalChatTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeMultiModalChatTests.java
@@ -52,6 +52,7 @@ import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.MESSAGE_FORMAT;
+import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.VIDEO_FPS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -435,6 +436,208 @@ public class DashScopeMultiModalChatTests {
         Generation response = chatModel.call(prompt).getResult();
 
         String text = response.getOutput().getText();
+        System.out.println("Chat Response Text: " + text);
+    }
+
+    @Test
+    @Tag("integration")
+    @EnabledIfEnvironmentVariable(named = "AI_DASHSCOPE_API_KEY", matches = ".+")
+    void integrationTestSingleVideoWithFpsFromOptions() {
+        // Create real API client with API key from environment
+        String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
+        DashScopeApi realApi = DashScopeApi.builder().apiKey(apiKey).build();
+
+        // Create chat model with default options that include fps
+        DashScopeChatOptions options = DashScopeChatOptions.builder()
+                .model(TEST_MODEL)
+                .multiModel(true)
+                .fps(2.0)
+                .build();
+
+        DashScopeChatModel chatModel = DashScopeChatModel.builder()
+                .dashScopeApi(realApi)
+                .defaultOptions(options)
+                .build();
+
+        // Create prompt with user message that contains a single video
+        Media media = Media.builder()
+                .mimeType(Media.Format.VIDEO_MP4)
+                .data(URI.create("https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20241115/cqqkru/1.mp4"))
+                .build();
+        UserMessage userMessage = UserMessage.builder()
+                .text(MULTIMODAL_VIDEO_PROMPT)
+                .media(media)
+                .build();
+        userMessage.getMetadata().put(MESSAGE_FORMAT, MessageFormat.VIDEO);
+        Prompt prompt = Prompt.builder().messages(userMessage).build();
+
+        // Call the chat model
+        Generation response = chatModel.call(prompt).getResult();
+
+        String text = response.getOutput().getText();
+        assertThat(text).isNotEmpty();
+        System.out.println("Chat Response Text: " + text);
+    }
+
+    @Test
+    @Tag("integration")
+    @EnabledIfEnvironmentVariable(named = "AI_DASHSCOPE_API_KEY", matches = ".+")
+    void integrationTestSingleVideoFpsMetadataOverridesOptions() {
+        // Create real API client with API key from environment
+        String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
+        DashScopeApi realApi = DashScopeApi.builder().apiKey(apiKey).build();
+
+        // Create chat model with default options that include fps
+        DashScopeChatOptions options = DashScopeChatOptions.builder()
+                .model(TEST_MODEL)
+                .multiModel(true)
+                .fps(4.0)
+                .build();
+
+        DashScopeChatModel chatModel = DashScopeChatModel.builder()
+                .dashScopeApi(realApi)
+                .defaultOptions(options)
+                .build();
+
+        // Create prompt with user message that contains a single video and message-level fps
+        Media media = Media.builder()
+                .mimeType(Media.Format.VIDEO_MP4)
+                .data(URI.create("https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20241115/cqqkru/1.mp4"))
+                .build();
+        UserMessage userMessage = UserMessage.builder()
+                .text(MULTIMODAL_VIDEO_PROMPT)
+                .media(media)
+                .build();
+        userMessage.getMetadata().put(MESSAGE_FORMAT, MessageFormat.VIDEO);
+        userMessage.getMetadata().put(VIDEO_FPS, 0.5);
+        Prompt prompt = Prompt.builder().messages(userMessage).build();
+
+        // Call the chat model
+        Generation response = chatModel.call(prompt).getResult();
+
+        String text = response.getOutput().getText();
+        assertThat(text).isNotEmpty();
+        System.out.println("Chat Response Text: " + text);
+    }
+
+    @Test
+    @Tag("integration")
+    @EnabledIfEnvironmentVariable(named = "AI_DASHSCOPE_API_KEY", matches = ".+")
+    void integrationTestVideoFrameListWithFps() {
+        // Create real API client with API key from environment
+        String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
+        DashScopeApi realApi = DashScopeApi.builder().apiKey(apiKey).build();
+
+        // Create chat model with default options that include fps
+        DashScopeChatOptions options = DashScopeChatOptions.builder()
+                .model(TEST_MODEL)
+                .multiModel(true)
+                .fps(2.0)
+                .build();
+
+        DashScopeChatModel chatModel = DashScopeChatModel.builder()
+                .dashScopeApi(realApi)
+                .defaultOptions(options)
+                .build();
+
+        // Create media list from the existing video frame URLs
+        List<Media> mediaList = new ArrayList<>();
+        for (String url : MULTIMODAL_VIDEO_FRAME_URLS) {
+            mediaList.add(new Media(MimeTypeUtils.IMAGE_JPEG, URI.create(url)));
+        }
+
+        UserMessage userMessage = UserMessage.builder()
+                .text(TEST_VIDEO_PROMPT)
+                .media(mediaList)
+                .build();
+        userMessage.getMetadata().put(MESSAGE_FORMAT, MessageFormat.VIDEO);
+        Prompt prompt = Prompt.builder().messages(userMessage).build();
+
+        // Call the chat model
+        Generation response = chatModel.call(prompt).getResult();
+
+        String text = response.getOutput().getText();
+        assertThat(text).isNotEmpty();
+        System.out.println("Chat Response Text: " + text);
+    }
+
+    @Test
+    @Tag("integration")
+    @EnabledIfEnvironmentVariable(named = "AI_DASHSCOPE_API_KEY", matches = ".+")
+    void integrationTestVideoWithoutFps() {
+        // Create real API client with API key from environment
+        String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
+        DashScopeApi realApi = DashScopeApi.builder().apiKey(apiKey).build();
+
+        // Create chat model without fps settings
+        DashScopeChatOptions options = DashScopeChatOptions.builder()
+                .model(TEST_MODEL)
+                .multiModel(true)
+                .build();
+
+        DashScopeChatModel chatModel = DashScopeChatModel.builder()
+                .dashScopeApi(realApi)
+                .defaultOptions(options)
+                .build();
+
+        // Create prompt with user message that contains a single video
+        Media media = Media.builder()
+                .mimeType(Media.Format.VIDEO_MP4)
+                .data(URI.create("https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20241115/cqqkru/1.mp4"))
+                .build();
+        UserMessage userMessage = UserMessage.builder()
+                .text(MULTIMODAL_VIDEO_PROMPT)
+                .media(media)
+                .build();
+        userMessage.getMetadata().put(MESSAGE_FORMAT, MessageFormat.VIDEO);
+        Prompt prompt = Prompt.builder().messages(userMessage).build();
+
+        // Call the chat model
+        Generation response = chatModel.call(prompt).getResult();
+
+        String text = response.getOutput().getText();
+        assertThat(text).isNotEmpty();
+        System.out.println("Chat Response Text: " + text);
+    }
+
+    @Test
+    @Tag("integration")
+    @EnabledIfEnvironmentVariable(named = "AI_DASHSCOPE_API_KEY", matches = ".+")
+    void integrationTestInvalidMetadataFpsFallsBackToOptions() {
+        // Create real API client with API key from environment
+        String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
+        DashScopeApi realApi = DashScopeApi.builder().apiKey(apiKey).build();
+
+        // Create chat model with default options that include fps
+        DashScopeChatOptions options = DashScopeChatOptions.builder()
+                .model(TEST_MODEL)
+                .multiModel(true)
+                .fps(2.0)
+                .build();
+
+        DashScopeChatModel chatModel = DashScopeChatModel.builder()
+                .dashScopeApi(realApi)
+                .defaultOptions(options)
+                .build();
+
+        // Create prompt with user message that contains invalid metadata fps
+        Media media = Media.builder()
+                .mimeType(Media.Format.VIDEO_MP4)
+                .data(URI.create("https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20241115/cqqkru/1.mp4"))
+                .build();
+        UserMessage userMessage = UserMessage.builder()
+                .text(MULTIMODAL_VIDEO_PROMPT)
+                .media(media)
+                .build();
+        userMessage.getMetadata().put(MESSAGE_FORMAT, MessageFormat.VIDEO);
+        userMessage.getMetadata().put(VIDEO_FPS, "abc");
+        Prompt prompt = Prompt.builder().messages(userMessage).build();
+
+        // Call the chat model
+        Generation response = chatModel.call(prompt).getResult();
+
+        String text = response.getOutput().getText();
+        assertThat(text).isNotEmpty();
         System.out.println("Chat Response Text: " + text);
     }
 

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpecTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/spec/DashScopeApiSpecTests.java
@@ -15,15 +15,18 @@
  */
 package com.alibaba.cloud.ai.dashscope.spec;
 
+import java.util.List;
 import java.util.Map;
 
+import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionMessage.MediaContent;
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionRequestParameter.ToolChoiceBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Test cases for {@link ToolChoiceBuilder}.
+ * Test cases for {@link DashScopeApiSpec} types.
  */
 class DashScopeApiSpecTests {
 
@@ -46,6 +49,31 @@ class DashScopeApiSpecTests {
     void functionToolChoice() {
         assertThat(ToolChoiceBuilder.function("getCurrentWeather"))
             .isEqualTo(Map.of("type", "function", "function", Map.of("name", "getCurrentWeather")));
+    }
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void mediaContentSerializesFpsForSingleVideo() throws Exception {
+        MediaContent content = new MediaContent("video", null, null, "https://example.com/1.mp4", null, 2.0);
+        String json = objectMapper.writeValueAsString(content);
+        assertThat(json).contains("\"video\":\"https://example.com/1.mp4\"");
+        assertThat(json).contains("\"fps\":2.0");
+    }
+
+    @Test
+    void mediaContentSerializesFpsForFrameList() throws Exception {
+        MediaContent content = new MediaContent("video", null, null,
+                List.of("https://example.com/f1.jpg", "https://example.com/f2.jpg"), null, 4.0);
+        String json = objectMapper.writeValueAsString(content);
+        assertThat(json).contains("\"fps\":4");
+    }
+
+    @Test
+    void mediaContentOmitsFpsWhenNull() throws Exception {
+        MediaContent content = new MediaContent("video", null, null, "https://example.com/1.mp4", null, (Double) null);
+        String json = objectMapper.writeValueAsString(content);
+        assertThat(json).doesNotContain("fps");
     }
 
 }


### PR DESCRIPTION
## Description
Add `fps` (frame extraction rate) support for video content in the DashScope multimodal chat model.

## Changes
- Added `fps` field to `DashScopeChatOptions` for default video frame-rate configuration.
- Added `VIDEO_FPS` metadata key to `DashScopeApiConstants` for per-message override.
- Added `fps` field to `DashScopeApiSpec.MediaContent` so it is serialized into video content items.
- `DashScopeChatModel` now passes fps when building video content items; message metadata `VIDEO_FPS` takes precedence over `DashScopeChatOptions.getFps()`.
- Added integration tests for single-video fps and message-level metadata override.
- Fixed `DashScopeApiSpecTests` class javadoc.

## Usage

```java
// Option 1: via default options
DashScopeChatOptions options = DashScopeChatOptions.builder()
        .model("qwen-vl-max")
        .multiModel(true)
        .fps(2)
        .build();

// Option 2: override per message via metadata
UserMessage userMessage = UserMessage.builder()
        .text("Describe this video")
        .media(videoMedia)
        .build();
userMessage.getMetadata().put(DashScopeApiConstants.VIDEO_FPS, 1);
