### PR TITLE
Fix Nacos 3.2.1 Prompt Registry integration

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-prompt/src/main/java/com/alibaba/cloud/ai/autoconfigure/prompt/PromptTemplateAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-prompt/src/main/java/com/alibaba/cloud/ai/autoconfigure/prompt/PromptTemplateAutoConfiguration.java
@@ -16,11 +16,18 @@
 package com.alibaba.cloud.ai.autoconfigure.prompt;
 
 import com.alibaba.cloud.ai.prompt.ConfigurablePromptTemplateFactory;
-
 import com.alibaba.cloud.ai.prompt.PromptTemplateBuilderConfigure;
 import com.alibaba.cloud.ai.prompt.PromptTemplateCustomizer;
+import com.alibaba.cloud.nacos.NacosConfigAutoConfiguration;
+import com.alibaba.cloud.nacos.NacosConfigProperties;
+import com.alibaba.nacos.api.ai.AiFactory;
+import com.alibaba.nacos.api.ai.AiService;
+import com.alibaba.nacos.api.exception.NacosException;
+
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -32,6 +39,7 @@ import org.springframework.context.annotation.Conditional;
  */
 
 @AutoConfiguration
+@AutoConfigureAfter(NacosConfigAutoConfiguration.class)
 @Conditional(PromptTmplNacosConfigCondition.class)
 @EnableConfigurationProperties(NacosPromptTmplProperties.class)
 public class PromptTemplateAutoConfiguration {
@@ -45,12 +53,20 @@ public class PromptTemplateAutoConfiguration {
 		return promptTemplateBuilderConfigure;
 	}
 
+	@Bean(destroyMethod = "shutdown")
+	@ConditionalOnBean(NacosConfigProperties.class)
+	@ConditionalOnMissingBean
+	public AiService nacosAiService(NacosConfigProperties nacosConfigProperties) throws NacosException {
+		return AiFactory.createAiService(nacosConfigProperties.assembleConfigServiceProperties());
+	}
+
 	// @formatter:off
 	@Bean
 	@ConditionalOnMissingBean
-	public ConfigurablePromptTemplateFactory configurablePromptTemplateFactory(PromptTemplateBuilderConfigure promptTemplateBuilderConfigure) {
+	public ConfigurablePromptTemplateFactory configurablePromptTemplateFactory(PromptTemplateBuilderConfigure promptTemplateBuilderConfigure,
+			ObjectProvider<AiService> aiServiceProvider) {
 
-		return new ConfigurablePromptTemplateFactory(promptTemplateBuilderConfigure);
+		return new ConfigurablePromptTemplateFactory(promptTemplateBuilderConfigure, aiServiceProvider.getIfAvailable());
 	}
 	// @formatter:on
 

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,7 @@
 
         <!-- Nacos -->
         <nacos3.version>3.1.0</nacos3.version>
+        <nacos-prompt-client.version>3.2.1</nacos-prompt-client.version>
         <nacos-client-mse-extension.version>1.0.6</nacos-client-mse-extension.version>
         <spring-alibaba-nacos-config.version>2023.0.1.3</spring-alibaba-nacos-config.version>
 

--- a/prompt/spring-ai-alibaba-prompt-nacos/pom.xml
+++ b/prompt/spring-ai-alibaba-prompt-nacos/pom.xml
@@ -70,6 +70,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.alibaba.nacos</groupId>
+            <artifactId>nacos-client</artifactId>
+            <version>${nacos-prompt-client.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.alibaba.cloud</groupId>
             <artifactId>spring-alibaba-nacos-config</artifactId>
             <version>${spring-alibaba-nacos-config.version}</version>

--- a/prompt/spring-ai-alibaba-prompt-nacos/src/main/java/com/alibaba/cloud/ai/prompt/ConfigurablePromptTemplateFactory.java
+++ b/prompt/spring-ai-alibaba-prompt-nacos/src/main/java/com/alibaba/cloud/ai/prompt/ConfigurablePromptTemplateFactory.java
@@ -18,9 +18,17 @@ package com.alibaba.cloud.ai.prompt;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 import com.alibaba.cloud.nacos.annotation.NacosConfigListener;
+import com.alibaba.nacos.api.ai.AiService;
+import com.alibaba.nacos.api.ai.listener.AbstractNacosPromptListener;
+import com.alibaba.nacos.api.ai.listener.NacosPromptEvent;
+import com.alibaba.nacos.api.ai.model.prompt.Prompt;
+import com.alibaba.nacos.api.ai.model.prompt.PromptVariable;
+import com.alibaba.nacos.api.exception.NacosException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,30 +44,40 @@ public class ConfigurablePromptTemplateFactory {
 
 	private final Map<String, ConfigurablePromptTemplate> templates = new ConcurrentHashMap<>();
 
+	private final Set<String> subscribedPrompts = ConcurrentHashMap.newKeySet();
+
 	private final PromptTemplateBuilderConfigure promptTemplateBuilderConfigure;
 
+	private final AiService aiService;
+
 	public ConfigurablePromptTemplateFactory(PromptTemplateBuilderConfigure promptTemplateBuilderConfigure) {
+		this(promptTemplateBuilderConfigure, null);
+	}
+
+	public ConfigurablePromptTemplateFactory(PromptTemplateBuilderConfigure promptTemplateBuilderConfigure,
+			AiService aiService) {
 		this.promptTemplateBuilderConfigure = promptTemplateBuilderConfigure;
+		this.aiService = aiService;
 	}
 
 	public ConfigurablePromptTemplate create(String name, Resource resource) {
-		return templates.computeIfAbsent(name, k -> new ConfigurablePromptTemplate(name, resource));
+		return createAndSubscribe(name, () -> new ConfigurablePromptTemplate(name, resource));
 	}
 
 	public ConfigurablePromptTemplate create(String name, String template) {
-		return templates.computeIfAbsent(name, k -> new ConfigurablePromptTemplate(name, template));
+		return createAndSubscribe(name, () -> new ConfigurablePromptTemplate(name, template));
 	}
 
 	public ConfigurablePromptTemplate create(String name, String template, Map<String, Object> model) {
-		return templates.computeIfAbsent(name, k -> new ConfigurablePromptTemplate(name, template, model));
+		return createAndSubscribe(name, () -> new ConfigurablePromptTemplate(name, template, model));
 	}
 
 	public ConfigurablePromptTemplate create(String name, Resource resource, Map<String, Object> model) {
-		return templates.computeIfAbsent(name, k -> new ConfigurablePromptTemplate(name, resource, model));
+		return createAndSubscribe(name, () -> new ConfigurablePromptTemplate(name, resource, model));
 	}
 
 	public ConfigurablePromptTemplate create(String name, PromptTemplate promptTemplate) {
-		return templates.computeIfAbsent(name, k -> new ConfigurablePromptTemplate(name, promptTemplate));
+		return createAndSubscribe(name, () -> new ConfigurablePromptTemplate(name, promptTemplate));
 	}
 
 	@NacosConfigListener(dataId = "spring.ai.alibaba.configurable.prompt", group = "DEFAULT_GROUP", initNotify = true)
@@ -71,21 +89,66 @@ public class ConfigurablePromptTemplateFactory {
 			if (!StringUtils.hasText(configuration.name()) || !StringUtils.hasText(configuration.template())) {
 				continue;
 			}
-			PromptTemplate.Builder promptTemplateBuilder = promptTemplateBuilderConfigure
-				.configure(PromptTemplate.builder()
-					.template(configuration.template())
-					.variables(configuration.model() == null ? new HashMap<>() : configuration.model()));
-
-			templates.put(configuration.name(),
-					new ConfigurablePromptTemplate(configuration.name(), promptTemplateBuilder.build()));
-
-			logger.info("OnPromptTemplateConfigChange,templateName:{},template:{},model:{}", configuration.name(),
-					configuration.template(), configuration.model());
+			updateTemplate(configuration.name(), configuration.template(), configuration.model());
 		}
 	}
 
 	public ConfigurablePromptTemplate getTemplate(String name) {
 		return templates.get(name);
+	}
+
+	private ConfigurablePromptTemplate createAndSubscribe(String name, Supplier<ConfigurablePromptTemplate> supplier) {
+		ConfigurablePromptTemplate template = templates.computeIfAbsent(name, key -> supplier.get());
+		subscribe(name);
+		return templates.getOrDefault(name, template);
+	}
+
+	private void subscribe(String name) {
+		if (aiService == null || !subscribedPrompts.add(name)) {
+			return;
+		}
+		try {
+			Prompt prompt = aiService.subscribePrompt(name, null, null, new AbstractNacosPromptListener() {
+				@Override
+				public void onEvent(NacosPromptEvent event) {
+					updateTemplate(event.getPromptKey(), event.getPrompt());
+				}
+			});
+			updateTemplate(name, prompt);
+		}
+		catch (NacosException ex) {
+			subscribedPrompts.remove(name);
+			logger.warn("Failed to subscribe Nacos prompt: {}", name, ex);
+		}
+	}
+
+	private void updateTemplate(String name, Prompt prompt) {
+		if (prompt == null) {
+			return;
+		}
+		Map<String, Object> model = new HashMap<>();
+		if (!CollectionUtils.isEmpty(prompt.getVariables())) {
+			for (PromptVariable variable : prompt.getVariables()) {
+				if (StringUtils.hasText(variable.getName()) && variable.getDefaultValue() != null) {
+					model.put(variable.getName(), variable.getDefaultValue());
+				}
+			}
+		}
+		updateTemplate(name, prompt.getTemplate(), model);
+	}
+
+	private void updateTemplate(String name, String template, Map<String, Object> model) {
+		if (!StringUtils.hasText(name) || !StringUtils.hasText(template)) {
+			return;
+		}
+		PromptTemplate.Builder promptTemplateBuilder = promptTemplateBuilderConfigure
+			.configure(PromptTemplate.builder()
+				.template(template)
+				.variables(model == null ? new HashMap<>() : model));
+
+		templates.put(name, new ConfigurablePromptTemplate(name, promptTemplateBuilder.build()));
+
+		logger.info("OnPromptTemplateConfigChange,templateName:{},template:{},model:{}", name, template, model);
 	}
 
 	public record ConfigurablePromptTemplateModel(String name, String template, Map<String, Object> model) {

--- a/prompt/spring-ai-alibaba-prompt-nacos/src/main/java/com/alibaba/cloud/ai/prompt/ConfigurablePromptTemplateFactory.java
+++ b/prompt/spring-ai-alibaba-prompt-nacos/src/main/java/com/alibaba/cloud/ai/prompt/ConfigurablePromptTemplateFactory.java
@@ -44,6 +44,8 @@ public class ConfigurablePromptTemplateFactory {
 
 	private final Map<String, ConfigurablePromptTemplate> templates = new ConcurrentHashMap<>();
 
+	private final Map<String, ConfigurablePromptTemplate> fallbackTemplates = new ConcurrentHashMap<>();
+
 	private final Set<String> subscribedPrompts = ConcurrentHashMap.newKeySet();
 
 	private final PromptTemplateBuilderConfigure promptTemplateBuilderConfigure;
@@ -98,7 +100,8 @@ public class ConfigurablePromptTemplateFactory {
 	}
 
 	private ConfigurablePromptTemplate createAndSubscribe(String name, Supplier<ConfigurablePromptTemplate> supplier) {
-		ConfigurablePromptTemplate template = templates.computeIfAbsent(name, key -> supplier.get());
+		ConfigurablePromptTemplate fallbackTemplate = fallbackTemplates.computeIfAbsent(name, key -> supplier.get());
+		ConfigurablePromptTemplate template = templates.computeIfAbsent(name, key -> fallbackTemplate);
 		subscribe(name);
 		return templates.getOrDefault(name, template);
 	}
@@ -124,17 +127,35 @@ public class ConfigurablePromptTemplateFactory {
 
 	private void updateTemplate(String name, Prompt prompt) {
 		if (prompt == null) {
+			ConfigurablePromptTemplate fallbackTemplate = fallbackTemplates.get(name);
+			if (fallbackTemplate == null) {
+				templates.remove(name);
+			}
+			else {
+				templates.put(name, fallbackTemplate);
+			}
 			return;
 		}
 		Map<String, Object> model = new HashMap<>();
+		String template = prompt.getTemplate();
 		if (!CollectionUtils.isEmpty(prompt.getVariables())) {
 			for (PromptVariable variable : prompt.getVariables()) {
-				if (StringUtils.hasText(variable.getName()) && variable.getDefaultValue() != null) {
-					model.put(variable.getName(), variable.getDefaultValue());
+				if (StringUtils.hasText(variable.getName())) {
+					template = normalizeVariablePlaceholder(template, variable.getName());
+					if (variable.getDefaultValue() != null) {
+						model.put(variable.getName(), variable.getDefaultValue());
+					}
 				}
 			}
 		}
-		updateTemplate(name, prompt.getTemplate(), model);
+		updateTemplate(name, template, model);
+	}
+
+	private String normalizeVariablePlaceholder(String template, String variableName) {
+		if (template == null) {
+			return null;
+		}
+		return template.replace("{{" + variableName + "}}", "{" + variableName + "}");
 	}
 
 	private void updateTemplate(String name, String template, Map<String, Object> model) {

--- a/prompt/spring-ai-alibaba-prompt-nacos/src/test/java/com/alibaba/cloud/ai/prompt/ConfigurablePromptTemplateFactoryTests.java
+++ b/prompt/spring-ai-alibaba-prompt-nacos/src/test/java/com/alibaba/cloud/ai/prompt/ConfigurablePromptTemplateFactoryTests.java
@@ -229,7 +229,7 @@ class ConfigurablePromptTemplateFactoryTests {
 	@Test
 	void testCreateLoadsPromptFromNacosPromptRegistry() throws Exception {
 		AiService aiService = mock(AiService.class);
-		Prompt prompt = createNacosPrompt(TEST_TEMPLATE_NAME, "Hello from Nacos, {name}!", "name", "Alice");
+		Prompt prompt = createNacosPrompt(TEST_TEMPLATE_NAME, "Hello from Nacos, {{name}}!", "name", "Alice");
 		when(aiService.subscribePrompt(eq(TEST_TEMPLATE_NAME), isNull(), isNull(), any())).thenReturn(prompt);
 		factory = new ConfigurablePromptTemplateFactory(new PromptTemplateBuilderConfigure(), aiService);
 
@@ -242,7 +242,7 @@ class ConfigurablePromptTemplateFactoryTests {
 	@Test
 	void testPromptRegistrySubscriptionUpdatesTemplate() throws Exception {
 		AiService aiService = mock(AiService.class);
-		Prompt initialPrompt = createNacosPrompt(TEST_TEMPLATE_NAME, "Hello, {name}!", "name", "Alice");
+		Prompt initialPrompt = createNacosPrompt(TEST_TEMPLATE_NAME, "Hello, {{name}}!", "name", "Alice");
 		ArgumentCaptor<AbstractNacosPromptListener> listenerCaptor = ArgumentCaptor
 			.forClass(AbstractNacosPromptListener.class);
 		when(aiService.subscribePrompt(eq(TEST_TEMPLATE_NAME), isNull(), isNull(), listenerCaptor.capture()))
@@ -250,10 +250,26 @@ class ConfigurablePromptTemplateFactoryTests {
 		factory = new ConfigurablePromptTemplateFactory(new PromptTemplateBuilderConfigure(), aiService);
 		factory.create(TEST_TEMPLATE_NAME, TEST_TEMPLATE_CONTENT);
 
-		Prompt updatedPrompt = createNacosPrompt(TEST_TEMPLATE_NAME, "Welcome, {name}!", "name", "Bob");
+		Prompt updatedPrompt = createNacosPrompt(TEST_TEMPLATE_NAME, "Welcome, {{name}}!", "name", "Bob");
 		listenerCaptor.getValue().onEvent(new NacosPromptEvent(TEST_TEMPLATE_NAME, updatedPrompt));
 
 		assertThat(factory.getTemplate(TEST_TEMPLATE_NAME).render()).isEqualTo("Welcome, Bob!");
+	}
+
+	@Test
+	void testPromptRegistryDeletionRestoresLocalTemplate() throws Exception {
+		AiService aiService = mock(AiService.class);
+		Prompt remotePrompt = createNacosPrompt(TEST_TEMPLATE_NAME, "Hello from Nacos, {{name}}!", "name", "Alice");
+		ArgumentCaptor<AbstractNacosPromptListener> listenerCaptor = ArgumentCaptor
+			.forClass(AbstractNacosPromptListener.class);
+		when(aiService.subscribePrompt(eq(TEST_TEMPLATE_NAME), isNull(), isNull(), listenerCaptor.capture()))
+			.thenReturn(remotePrompt);
+		factory = new ConfigurablePromptTemplateFactory(new PromptTemplateBuilderConfigure(), aiService);
+		factory.create(TEST_TEMPLATE_NAME, TEST_TEMPLATE_CONTENT, Map.of("name", "Local"));
+
+		listenerCaptor.getValue().onEvent(new NacosPromptEvent(TEST_TEMPLATE_NAME, null));
+
+		assertThat(factory.getTemplate(TEST_TEMPLATE_NAME).render()).isEqualTo("Hello, Local!");
 	}
 
 	private Prompt createNacosPrompt(String name, String template, String variableName, String defaultValue) {

--- a/prompt/spring-ai-alibaba-prompt-nacos/src/test/java/com/alibaba/cloud/ai/prompt/ConfigurablePromptTemplateFactoryTests.java
+++ b/prompt/spring-ai-alibaba-prompt-nacos/src/test/java/com/alibaba/cloud/ai/prompt/ConfigurablePromptTemplateFactoryTests.java
@@ -15,8 +15,14 @@
  */
 package com.alibaba.cloud.ai.prompt;
 
+import com.alibaba.nacos.api.ai.AiService;
+import com.alibaba.nacos.api.ai.listener.AbstractNacosPromptListener;
+import com.alibaba.nacos.api.ai.listener.NacosPromptEvent;
+import com.alibaba.nacos.api.ai.model.prompt.Prompt;
+import com.alibaba.nacos.api.ai.model.prompt.PromptVariable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.ai.template.st.StTemplateRenderer;
 import org.springframework.core.io.ByteArrayResource;
@@ -25,6 +31,12 @@ import org.springframework.core.io.Resource;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test cases for ConfigurablePromptTemplateFactory. Tests template creation, retrieval,
@@ -212,6 +224,42 @@ class ConfigurablePromptTemplateFactoryTests {
 		ConfigurablePromptTemplate template = factory.getTemplate(TEST_TEMPLATE_NAME);
 		assertThat(template.render()).isNotEqualTo("Hello, John!");
 		assertThat(template.render()).isEqualTo("Hello, yuhuangbin!");
+	}
+
+	@Test
+	void testCreateLoadsPromptFromNacosPromptRegistry() throws Exception {
+		AiService aiService = mock(AiService.class);
+		Prompt prompt = createNacosPrompt(TEST_TEMPLATE_NAME, "Hello from Nacos, {name}!", "name", "Alice");
+		when(aiService.subscribePrompt(eq(TEST_TEMPLATE_NAME), isNull(), isNull(), any())).thenReturn(prompt);
+		factory = new ConfigurablePromptTemplateFactory(new PromptTemplateBuilderConfigure(), aiService);
+
+		ConfigurablePromptTemplate template = factory.create(TEST_TEMPLATE_NAME, TEST_TEMPLATE_CONTENT);
+
+		assertThat(template.render()).isEqualTo("Hello from Nacos, Alice!");
+		verify(aiService).subscribePrompt(eq(TEST_TEMPLATE_NAME), isNull(), isNull(), any());
+	}
+
+	@Test
+	void testPromptRegistrySubscriptionUpdatesTemplate() throws Exception {
+		AiService aiService = mock(AiService.class);
+		Prompt initialPrompt = createNacosPrompt(TEST_TEMPLATE_NAME, "Hello, {name}!", "name", "Alice");
+		ArgumentCaptor<AbstractNacosPromptListener> listenerCaptor = ArgumentCaptor
+			.forClass(AbstractNacosPromptListener.class);
+		when(aiService.subscribePrompt(eq(TEST_TEMPLATE_NAME), isNull(), isNull(), listenerCaptor.capture()))
+			.thenReturn(initialPrompt);
+		factory = new ConfigurablePromptTemplateFactory(new PromptTemplateBuilderConfigure(), aiService);
+		factory.create(TEST_TEMPLATE_NAME, TEST_TEMPLATE_CONTENT);
+
+		Prompt updatedPrompt = createNacosPrompt(TEST_TEMPLATE_NAME, "Welcome, {name}!", "name", "Bob");
+		listenerCaptor.getValue().onEvent(new NacosPromptEvent(TEST_TEMPLATE_NAME, updatedPrompt));
+
+		assertThat(factory.getTemplate(TEST_TEMPLATE_NAME).render()).isEqualTo("Welcome, Bob!");
+	}
+
+	private Prompt createNacosPrompt(String name, String template, String variableName, String defaultValue) {
+		Prompt prompt = new Prompt(name, "1.0.0", template);
+		prompt.setVariables(List.of(new PromptVariable(variableName, defaultValue, null)));
+		return prompt;
 	}
 
 }


### PR DESCRIPTION
## Summary

- create the Nacos AI client from the existing Nacos configuration
- subscribe each configurable prompt by its Prompt Registry key
- apply remote templates and variable defaults on initial load and updates
- keep the legacy aggregate configuration listener for backward compatibility

## Tests

- `mvn -pl auto-configurations/spring-ai-alibaba-autoconfigure-nacos-prompt -am test`

Closes #246