### PR TITLE
Merge DashScope streaming tool calls by index

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelper.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelper.java
@@ -125,48 +125,47 @@ public class DashScopeAiStreamFunctionCallingHelper {
         String phase = (current.phase() != null ? current.phase() : previous.phase());
 
 		List<ToolCall> toolCalls = new ArrayList<>();
-		ToolCall lastPreviousToolCall = null;
 		if (!CollectionUtils.isEmpty(previous.toolCalls())) {
-			lastPreviousToolCall = previous.toolCalls().get(previous.toolCalls().size() - 1);
-			if (previous.toolCalls().size() > 1) {
-				toolCalls.addAll(previous.toolCalls().subList(0, previous.toolCalls().size() - 1));
-			}
+			toolCalls.addAll(previous.toolCalls());
 		}
 
 		if (!CollectionUtils.isEmpty(current.toolCalls())) {
-			if (current.toolCalls().size() > 1) {
-				throw new IllegalStateException("Currently only one tool call is supported per message!");
-			}
-			var currentToolCall = current.toolCalls().iterator().next();
-			if (isSameStreamingToolCall(lastPreviousToolCall, currentToolCall)) {
-				toolCalls.add(merge(lastPreviousToolCall, currentToolCall));
-			}
-			else {
-				if (lastPreviousToolCall != null) {
-					toolCalls.add(lastPreviousToolCall);
+			for (ToolCall currentToolCall : current.toolCalls()) {
+				int matchingIndex = findMatchingToolCallIndex(toolCalls, currentToolCall);
+				if (matchingIndex >= 0) {
+					toolCalls.set(matchingIndex, merge(toolCalls.get(matchingIndex), currentToolCall));
 				}
-				toolCalls.add(currentToolCall);
-			}
-		}
-		else {
-			if (lastPreviousToolCall != null) {
-				toolCalls.add(lastPreviousToolCall);
+				else {
+					toolCalls.add(currentToolCall);
+				}
 			}
 		}
 		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls, reasoningContent, partial, phase, annotations, status);
 	}
 
-	private boolean isSameStreamingToolCall(ToolCall previous, ToolCall current) {
-		if (previous == null || current == null) {
-			return false;
+	private int findMatchingToolCallIndex(List<ToolCall> previousToolCalls, ToolCall currentToolCall) {
+		if (currentToolCall.index() != null) {
+			for (int i = 0; i < previousToolCalls.size(); i++) {
+				ToolCall previousToolCall = previousToolCalls.get(i);
+				if (currentToolCall.index().equals(previousToolCall.index())) {
+					return i;
+				}
+			}
 		}
-		if (StringUtils.hasText(previous.id()) && StringUtils.hasText(current.id())) {
-			return previous.id().equals(current.id());
+		if (StringUtils.hasText(currentToolCall.id())) {
+			for (int i = 0; i < previousToolCalls.size(); i++) {
+				ToolCall previousToolCall = previousToolCalls.get(i);
+				if ((currentToolCall.index() == null || previousToolCall.index() == null)
+						&& currentToolCall.id().equals(previousToolCall.id())) {
+					return i;
+				}
+			}
 		}
-        if (previous.index() != null && current.index() != null) {
-            return previous.index().equals(current.index());
-        }
-        return !StringUtils.hasText(current.id());
+		if (currentToolCall.index() == null && !StringUtils.hasText(currentToolCall.id())
+				&& !previousToolCalls.isEmpty()) {
+			return previousToolCalls.size() - 1;
+		}
+		return -1;
 	}
 
 	private ToolCall merge(ToolCall previous, ToolCall current) {
@@ -180,7 +179,7 @@ public class DashScopeAiStreamFunctionCallingHelper {
 
         String id = (StringUtils.hasText(current.id()) ? current.id() : previous.id());
 		String type = (StringUtils.hasText(current.type()) ? current.type() : previous.type());
-		Integer index = (current.index() != null && current.index() != 0 ? current.index() : previous.index());
+		Integer index = (current.index() != null ? current.index() : previous.index());
 
 
 		ChatCompletionFunction function = merge(previous.function(), current.function());

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelperTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelperTests.java
@@ -117,6 +117,38 @@ public class DashScopeAiStreamFunctionCallingHelperTests {
 	}
 
 	@Test
+	void testMergeToolCallChunksByIndexInsteadOfId() {
+		ChatCompletionChunk previous = createChunkWithIndexedToolCall("request-1", "tool-1", "get_weather", "{\"location",
+				0);
+		ChatCompletionChunk current = createChunkWithIndexedToolCall("request-1", "tool-2", null, "\":\"Beijing\"}", 0);
+
+		ChatCompletionChunk result = helperWithIncrementalOutput.merge(previous, current);
+
+		List<ToolCall> toolCalls = result.output().choices().get(0).message().toolCalls();
+		assertEquals(1, toolCalls.size());
+		assertEquals(0, toolCalls.get(0).index());
+		assertEquals("get_weather", toolCalls.get(0).function().name());
+		assertEquals("{\"location\":\"Beijing\"}", toolCalls.get(0).function().arguments());
+	}
+
+	@Test
+	void testMergeInterleavedToolCallChunksByIndex() {
+		ChatCompletionChunk previous = createChunkWithToolCalls("request-1",
+				new ToolCall("tool-1", "function", new ChatCompletionFunction("get_weather", "{\"location"), 0),
+				new ToolCall("tool-2", "function", new ChatCompletionFunction("get_time", "{\"timezone"), 1));
+		ChatCompletionChunk current = createChunkWithIndexedToolCall("request-1", null, null, "\":\"Beijing\"}", 0);
+
+		ChatCompletionChunk result = helperWithIncrementalOutput.merge(previous, current);
+
+		List<ToolCall> toolCalls = result.output().choices().get(0).message().toolCalls();
+		assertEquals(2, toolCalls.size());
+		assertEquals(0, toolCalls.get(0).index());
+		assertEquals("{\"location\":\"Beijing\"}", toolCalls.get(0).function().arguments());
+		assertEquals(1, toolCalls.get(1).index());
+		assertEquals("{\"timezone", toolCalls.get(1).function().arguments());
+	}
+
+	@Test
 	void testIsStreamingToolFunctionCall() {
 		// Test isStreamingToolFunctionCall method
 		ChatCompletionChunk chunkWithTool = createChunkWithToolCall("request-1", "tool-1", "function-1",
@@ -242,9 +274,28 @@ public class DashScopeAiStreamFunctionCallingHelperTests {
 	// Helper method: Create a ChatCompletionChunk with tool call and finish reason
 	private ChatCompletionChunk createChunkWithToolCall(String requestId, String toolId, String functionName,
 			String arguments, ChatCompletionFinishReason finishReason) {
+		return createChunkWithToolCall(requestId, toolId, functionName, arguments, finishReason, null);
+	}
+
+	private ChatCompletionChunk createChunkWithIndexedToolCall(String requestId, String toolId, String functionName,
+			String arguments, Integer index) {
+		return createChunkWithToolCall(requestId, toolId, functionName, arguments, null, index);
+	}
+
+	private ChatCompletionChunk createChunkWithToolCall(String requestId, String toolId, String functionName,
+			String arguments, ChatCompletionFinishReason finishReason, Integer index) {
 		ChatCompletionFunction function = new ChatCompletionFunction(functionName, arguments);
-		ToolCall toolCall = new ToolCall(toolId, "function", function, null);
-		ChatCompletionMessage message = new ChatCompletionMessage("", Role.ASSISTANT, null, null, List.of(toolCall),
+		ToolCall toolCall = new ToolCall(toolId, "function", function, index);
+		return createChunkWithToolCalls(requestId, finishReason, toolCall);
+	}
+
+	private ChatCompletionChunk createChunkWithToolCalls(String requestId, ToolCall... toolCalls) {
+		return createChunkWithToolCalls(requestId, null, toolCalls);
+	}
+
+	private ChatCompletionChunk createChunkWithToolCalls(String requestId, ChatCompletionFinishReason finishReason,
+			ToolCall... toolCalls) {
+		ChatCompletionMessage message = new ChatCompletionMessage("", Role.ASSISTANT, null, null, List.of(toolCalls),
 				null, null, null, null, null);
 		Choice choice = new Choice(finishReason, message, null, 0);
 		ChatCompletionOutput output = new ChatCompletionOutput(null, List.of(choice), null);


### PR DESCRIPTION
## Summary

- use the tool call index as the primary identity for streaming chunks
- merge interleaved parallel tool calls with the matching accumulated entry
- keep ID-based fallback behavior for chunks without an index
- add regression coverage for differing IDs and interleaved indexes

This follows up on #277, which fixed repeated IDs but still compared only the last accumulated tool call.

## Tests

- `mvn -pl models/dashscope -Dtest=DashScopeAiStreamFunctionCallingHelperTests test`

Closes #291