### PR TITLE
[Contribute] fix: preserve parallel tool call order by index (#291)

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -87,6 +87,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Comparator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -405,13 +406,23 @@ public class DashScopeChatModel implements ChatModel {
 		this.defaultOptions = options;
 	}
 
-	private Generation buildGeneration(Choice choice, Map<String, Object> metadata,
+	static List<DashScopeApiSpec.ChatCompletionMessage.ToolCall> sortToolCallsByIndex(
+		List<DashScopeApiSpec.ChatCompletionMessage.ToolCall> toolCalls) {
+		// Preserve tool-call order by their `index` so that parallel tool calls
+		// delivered as interleaved stream chunks are aggregated into the correct
+		// positions downstream (see issue #291). Tool calls without an index sort last.
+		return toolCalls.stream()
+				.sorted(Comparator.comparingInt(tc -> tc.index() == null ? Integer.MAX_VALUE : tc.index()))
+				.toList();
+	}
+
+private Generation buildGeneration(Choice choice, Map<String, Object> metadata,
 			ChatCompletionRequest request) {
 		// Use the validator to filter and validate tool calls
 		List<DashScopeApiSpec.ChatCompletionMessage.ToolCall> validatedToolCalls =
 				toolCallingValidator.validate(choice.message().toolCalls(), choice.finishReason());
 
-		List<AssistantMessage.ToolCall> toolCalls = validatedToolCalls.stream()
+		List<AssistantMessage.ToolCall> toolCalls = sortToolCallsByIndex(validatedToolCalls).stream()
 				.map(toolCall -> new AssistantMessage.ToolCall(toolCall.id(), "function",
 						toolCall.function().name(), toolCall.function().arguments()))
 				.toList();

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
@@ -1304,4 +1304,20 @@ class DashScopeChatModelTests {
         assertThat(request).isNotNull();
         assertThat(request.parameters().enableCodeInterpreter()).isNull();
     }
+
+    @Test
+    void testParallelToolCallIndexOrderPreserved() {
+		// Issue #291: parallel tool calls carry an explicit `index`. sortToolCallsByIndex
+		// must preserve index order so that interleaved stream chunks aggregate into the
+		// correct positions downstream. Feed them reversed (index=1 before index=0) and
+		// assert they come back ordered by index.
+		ToolCall tcIndex1 = new ToolCall("call-1", "function", new ChatCompletionFunction("get_time", "city=Shanghai"), 1);
+		ToolCall tcIndex0 = new ToolCall("call-0", "function", new ChatCompletionFunction("get_weather", "location=Beijing"), 0);
+
+		List<ToolCall> sorted = DashScopeChatModel.sortToolCallsByIndex(List.of(tcIndex1, tcIndex0));
+		assertThat(sorted).hasSize(2);
+		// After sorting by index, index=0 (get_weather) must precede index=1 (get_time).
+		assertThat(sorted.get(0).function().name()).isEqualTo("get_weather");
+		assertThat(sorted.get(1).function().name()).isEqualTo("get_time");
+	}
 }


### PR DESCRIPTION
## Problem
DashScope returns parallel tool calls each carrying an explicit index. Previously uildGeneration mapped them to AssistantMessage.ToolCall without preserving that order, so when parallel tool calls arrive as interleaved stream chunks they could be aggregated into the wrong positions downstream.

## Fix
- Extracted the ordering into a package-private static helper sortToolCallsByIndex(...) that sorts tool calls by their index (tool calls without an index sort last).
- uildGeneration now calls this helper before mapping to AssistantMessage.ToolCall.
- Single tool calls are unaffected (sorting is a no-op).

## Test
- Added 	estParallelToolCallIndexOrderPreserved: feeds two tool calls in reversed index order (index=1 before index=0) and asserts they come back ordered by index (get_weather before get_time).
- The test calls the helper directly, avoiding the tool-execution path, so it runs deterministically.

## Verification
mvn -pl models/dashscope test -Dtest=DashScopeChatModelTests#testParallelToolCallIndexOrderPreserved -> BUILD SUCCESS.

Related issue: #291