### PR TITLE
feat(dashscope): stream tool-call chunks before merged result

### DIFF
--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelper.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelper.java
@@ -93,10 +93,25 @@ public class DashScopeAiStreamFunctionCallingHelper {
 				if (!insideToolCall.getAndSet(false)) {
 					return Flux.empty();
 				}
-				ChatCompletionChunk merged = mergedToolCall.getAndSet(null);
+				ChatCompletionChunk merged = withFinishReason(mergedToolCall.getAndSet(null),
+						ChatCompletionFinishReason.TOOL_CALLS);
 				return shouldEmitMerged(lastChunk.get(), merged) ? Flux.just(merged) : Flux.empty();
 			}));
 		});
+	}
+
+	private ChatCompletionChunk withFinishReason(ChatCompletionChunk chunk,
+			ChatCompletionFinishReason finishReason) {
+		Choice choice = checkChatCompletionChunk(chunk);
+		if (choice == null) {
+			return chunk;
+		}
+
+		Choice completedChoice = new Choice(finishReason, choice.message(), choice.logprobs(), choice.index());
+		ChatCompletionOutput output = chunk.output();
+		return new ChatCompletionChunk(chunk.requestId(),
+				new ChatCompletionOutput(output.text(), List.of(completedChoice), output.searchInfo()), chunk.usage(),
+				chunk.o());
 	}
 
 	private Flux<ChatCompletionChunk> emitRawAndMerged(ChatCompletionChunk raw, ChatCompletionChunk merged) {

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelper.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelper.java
@@ -28,9 +28,14 @@ import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionOutput
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.TokenUsage;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Helper class to support Streaming function calling. It can merge the streamed
@@ -47,6 +52,65 @@ public class DashScopeAiStreamFunctionCallingHelper {
 
 	public DashScopeAiStreamFunctionCallingHelper(Boolean incrementalOutput) {
 		this.incrementalOutput = incrementalOutput;
+	}
+
+	/**
+	 * Emits each streaming tool-call chunk as received, followed by the merged tool
+	 * call when the sequence finishes. Non-tool chunks pass through unchanged.
+	 * @param chunks source completion chunks
+	 * @return raw chunks with a merged tool-call chunk appended when available
+	 */
+	Flux<ChatCompletionChunk> mergeStreamingToolCallChunks(Flux<ChatCompletionChunk> chunks) {
+		return Flux.defer(() -> {
+			AtomicBoolean insideToolCall = new AtomicBoolean(false);
+			AtomicReference<ChatCompletionChunk> mergedToolCall = new AtomicReference<>();
+			AtomicReference<ChatCompletionChunk> lastChunk = new AtomicReference<>();
+
+			return chunks.concatMap(chunk -> {
+				lastChunk.set(chunk);
+				if (isStreamingToolFunctionCall(chunk)) {
+					if (!insideToolCall.getAndSet(true)) {
+						mergedToolCall.set(null);
+					}
+					mergedToolCall.set(merge(mergedToolCall.get(), chunk));
+
+					if (isStreamingToolFunctionCallFinish(chunk)) {
+						insideToolCall.set(false);
+						return emitRawAndMerged(chunk, mergedToolCall.getAndSet(null));
+					}
+					return Mono.just(chunk);
+				}
+
+				if (insideToolCall.get()) {
+					mergedToolCall.set(merge(mergedToolCall.get(), chunk));
+					if (hasTerminalFinishReason(chunk)) {
+						insideToolCall.set(false);
+						return emitRawAndMerged(chunk, mergedToolCall.getAndSet(null));
+					}
+				}
+				return Mono.just(chunk);
+			}).concatWith(Flux.defer(() -> {
+				if (!insideToolCall.getAndSet(false)) {
+					return Flux.empty();
+				}
+				ChatCompletionChunk merged = mergedToolCall.getAndSet(null);
+				return shouldEmitMerged(lastChunk.get(), merged) ? Flux.just(merged) : Flux.empty();
+			}));
+		});
+	}
+
+	private Flux<ChatCompletionChunk> emitRawAndMerged(ChatCompletionChunk raw, ChatCompletionChunk merged) {
+		return shouldEmitMerged(raw, merged) ? Flux.just(raw, merged) : Flux.just(raw);
+	}
+
+	private boolean shouldEmitMerged(ChatCompletionChunk raw, ChatCompletionChunk merged) {
+		return isStreamingToolFunctionCall(merged) && !Objects.equals(raw, merged);
+	}
+
+	private boolean hasTerminalFinishReason(ChatCompletionChunk chunk) {
+		Choice choice = checkChatCompletionChunk(chunk);
+		return choice != null && choice.finishReason() != null
+				&& choice.finishReason() != ChatCompletionFinishReason.NULL;
 	}
 
 	/**

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelper.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelper.java
@@ -74,7 +74,7 @@ public class DashScopeAiStreamFunctionCallingHelper {
 					}
 					mergedToolCall.set(merge(mergedToolCall.get(), chunk));
 
-					if (isStreamingToolFunctionCallFinish(chunk)) {
+					if (hasTerminalFinishReason(chunk)) {
 						insideToolCall.set(false);
 						return emitRawAndMerged(chunk, mergedToolCall.getAndSet(null));
 					}

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -61,7 +61,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -606,7 +605,6 @@ public class DashScopeApi {
 		Assert.notNull(chatRequest, "The request body can not be null.");
 		Assert.isTrue(chatRequest.stream(), "Request must set the stream property to true.");
 
-		AtomicBoolean isInsideTool = new AtomicBoolean(false);
 		boolean incrementalOutput = chatRequest.parameters() != null
 				&& chatRequest.parameters().incrementalOutput() != null && chatRequest.parameters().incrementalOutput();
 		DashScopeAiStreamFunctionCallingHelper chunkMerger = new DashScopeAiStreamFunctionCallingHelper(
@@ -640,27 +638,7 @@ public class DashScopeApi {
 				}
 				return chunk;
 			})
-			.map(chunk -> {
-				if (chunkMerger.isStreamingToolFunctionCall(chunk)) {
-					isInsideTool.set(true);
-				}
-				return chunk;
-			})
-			.windowUntil(chunk -> {
-				if (isInsideTool.get() && chunkMerger.isStreamingToolFunctionCallFinish(chunk)) {
-					isInsideTool.set(false);
-					return true;
-				}
-				return !isInsideTool.get();
-			})
-			.concatMapIterable(window -> {
-				Mono<DashScopeApiSpec.ChatCompletionChunk> monoChunk = window.reduce(
-                        new DashScopeApiSpec.ChatCompletionChunk(null, null, null, null),
-						chunkMerger::merge
-                );
-				return List.of(monoChunk);
-			})
-			.flatMap(mono -> mono);
+			.transform(chunkMerger::mergeStreamingToolCallChunks);
 	}
 
 	/**

--- a/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/models/dashscope/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -36,6 +36,7 @@ import com.alibaba.cloud.ai.dashscope.common.DashScopeException;
 import com.alibaba.cloud.ai.tool.observation.inner.ToolCallReactiveContextHolder;
 import com.alibaba.cloud.ai.tool.validator.DefaultToolCallValidator;
 import com.alibaba.cloud.ai.tool.validator.ToolCallValidator;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
@@ -70,6 +71,7 @@ import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.support.UsageCalculator;
 import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.ai.util.json.JsonParser;
 import org.springframework.http.ResponseEntity;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
@@ -297,7 +299,8 @@ public class DashScopeChatModel implements ChatModel {
             );
 
 			Flux<ChatResponse> flux = chatResponse.flatMap(response -> {
-					if (toolExecutionEligibilityPredicate.isToolExecutionRequired(prompt.getOptions(), response)) {
+					if (isStreamingToolExecutionReady(response)
+							&& toolExecutionEligibilityPredicate.isToolExecutionRequired(prompt.getOptions(), response)) {
 
 						return Flux.deferContextual((ctx) -> {
 
@@ -336,6 +339,31 @@ public class DashScopeChatModel implements ChatModel {
 
 			return new MessageAggregator().aggregate(flux, observationContext::setResponse);
 		});
+	}
+
+	private boolean isStreamingToolExecutionReady(ChatResponse response) {
+		if (!response.hasToolCalls()) {
+			return true;
+		}
+
+		return response.getResults().stream()
+			.filter(generation -> generation.getOutput().hasToolCalls())
+			.allMatch(generation -> StringUtils.hasText(generation.getMetadata().getFinishReason())
+					&& generation.getOutput().getToolCalls().stream().allMatch(this::hasValidJsonArguments));
+	}
+
+	private boolean hasValidJsonArguments(AssistantMessage.ToolCall toolCall) {
+		if (!StringUtils.hasText(toolCall.arguments())) {
+			return true;
+		}
+
+		try {
+			JsonParser.getObjectMapper().readTree(toolCall.arguments());
+			return true;
+		}
+		catch (JsonProcessingException ex) {
+			return false;
+		}
 	}
 
 	private static String finishReasonToMetadataValue(DashScopeApiSpec.ChatCompletionFinishReason finishReason) {

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelperTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelperTests.java
@@ -26,6 +26,8 @@ import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.ChatCompletionOutput
 import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.TokenUsage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
 
 import java.util.List;
 
@@ -54,6 +56,90 @@ public class DashScopeAiStreamFunctionCallingHelperTests {
 		helper = new DashScopeAiStreamFunctionCallingHelper();
 		// Create helper with incrementalOutput = true
 		helperWithIncrementalOutput = new DashScopeAiStreamFunctionCallingHelper(true);
+	}
+
+	@Test
+	void mergeStreamingToolCallChunksEmitsFragmentsAndMergedChunk() {
+		ChatCompletionChunk first = createChunkWithToolCall("request-1", "tool-1", "get_weather",
+				"{\"city\":\"Bei");
+		ChatCompletionChunk second = createChunkWithToolCall("request-1", null, null, "jing\"}",
+				ChatCompletionFinishReason.TOOL_CALLS);
+
+		StepVerifier.create(helperWithIncrementalOutput.mergeStreamingToolCallChunks(Flux.just(first, second)))
+			.expectNext(first, second)
+			.assertNext(merged -> {
+				ToolCall toolCall = merged.output().choices().get(0).message().toolCalls().get(0);
+				assertEquals("tool-1", toolCall.id());
+				assertEquals("get_weather", toolCall.function().name());
+				assertEquals("{\"city\":\"Beijing\"}", toolCall.function().arguments());
+				assertEquals(ChatCompletionFinishReason.TOOL_CALLS,
+						merged.output().choices().get(0).finishReason());
+			})
+			.verifyComplete();
+	}
+
+	@Test
+	void mergeStreamingToolCallChunksLeavesTextChunksUnchanged() {
+		ChatCompletionChunk first = createSimpleChunk("request-1", "Bei", Role.ASSISTANT, null);
+		ChatCompletionChunk second = createSimpleChunk("request-1", "jing", Role.ASSISTANT,
+				ChatCompletionFinishReason.STOP);
+
+		StepVerifier.create(helperWithIncrementalOutput.mergeStreamingToolCallChunks(Flux.just(first, second)))
+			.expectNext(first, second)
+			.verifyComplete();
+	}
+
+	@Test
+	void mergeStreamingToolCallChunksDoesNotDuplicateSingleFinishedChunk() {
+		ChatCompletionChunk finished = createChunkWithToolCall("request-1", "tool-1", "get_weather",
+				"{\"city\":\"Beijing\"}", ChatCompletionFinishReason.TOOL_CALLS);
+
+		StepVerifier.create(helperWithIncrementalOutput.mergeStreamingToolCallChunks(Flux.just(finished)))
+			.expectNext(finished)
+			.verifyComplete();
+	}
+
+	@Test
+	void mergeStreamingToolCallChunksPreservesNonIncrementalFinalChunk() {
+		ChatCompletionChunk partial = createChunkWithToolCall("request-1", "tool-1", "get_weather",
+				"{\"city\":\"Bei");
+		ChatCompletionChunk complete = createChunkWithToolCall("request-1", "tool-1", "get_weather",
+				"{\"city\":\"Beijing\"}", ChatCompletionFinishReason.TOOL_CALLS);
+
+		StepVerifier.create(helper.mergeStreamingToolCallChunks(Flux.just(partial, complete)))
+			.expectNext(partial, complete)
+			.verifyComplete();
+	}
+
+	@Test
+	void mergeStreamingToolCallChunksFlushesMergedChunkOnStop() {
+		ChatCompletionChunk first = createChunkWithToolCall("request-1", "tool-1", "get_weather",
+				"{\"city\":\"Bei");
+		ChatCompletionChunk second = createChunkWithToolCall("request-1", null, null, "jing\"}");
+		ChatCompletionChunk stop = createSimpleChunk("request-1", "", Role.ASSISTANT,
+				ChatCompletionFinishReason.STOP);
+
+		StepVerifier.create(helperWithIncrementalOutput.mergeStreamingToolCallChunks(Flux.just(first, second, stop)))
+			.expectNext(first, second, stop)
+			.assertNext(merged -> {
+				assertEquals(ChatCompletionFinishReason.STOP, merged.output().choices().get(0).finishReason());
+				assertEquals("{\"city\":\"Beijing\"}", merged.output().choices().get(0).message().toolCalls()
+					.get(0).function().arguments());
+			})
+			.verifyComplete();
+	}
+
+	@Test
+	void mergeStreamingToolCallChunksFlushesMergedChunkOnCompletion() {
+		ChatCompletionChunk first = createChunkWithToolCall("request-1", "tool-1", "get_weather",
+				"{\"city\":\"Bei");
+		ChatCompletionChunk second = createChunkWithToolCall("request-1", null, null, "jing\"}");
+
+		StepVerifier.create(helperWithIncrementalOutput.mergeStreamingToolCallChunks(Flux.just(first, second)))
+			.expectNext(first, second)
+			.assertNext(merged -> assertEquals("{\"city\":\"Beijing\"}", merged.output().choices().get(0)
+				.message().toolCalls().get(0).function().arguments()))
+			.verifyComplete();
 	}
 
 	@Test

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelperTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelperTests.java
@@ -137,8 +137,28 @@ public class DashScopeAiStreamFunctionCallingHelperTests {
 
 		StepVerifier.create(helperWithIncrementalOutput.mergeStreamingToolCallChunks(Flux.just(first, second)))
 			.expectNext(first, second)
-			.assertNext(merged -> assertEquals("{\"city\":\"Beijing\"}", merged.output().choices().get(0)
-				.message().toolCalls().get(0).function().arguments()))
+			.assertNext(merged -> {
+				assertEquals(ChatCompletionFinishReason.TOOL_CALLS,
+						merged.output().choices().get(0).finishReason());
+				assertEquals("{\"city\":\"Beijing\"}",
+						merged.output().choices().get(0).message().toolCalls().get(0).function().arguments());
+			})
+			.verifyComplete();
+	}
+
+	@Test
+	void mergeStreamingToolCallChunksMarksSingleChunkCompleteWhenStreamEnds() {
+		ChatCompletionChunk complete = createChunkWithToolCall("request-1", "tool-1", "get_weather",
+				"{\"city\":\"Beijing\"}");
+
+		StepVerifier.create(helperWithIncrementalOutput.mergeStreamingToolCallChunks(Flux.just(complete)))
+			.expectNext(complete)
+			.assertNext(merged -> {
+				assertEquals(ChatCompletionFinishReason.TOOL_CALLS,
+						merged.output().choices().get(0).finishReason());
+				assertEquals("{\"city\":\"Beijing\"}",
+						merged.output().choices().get(0).message().toolCalls().get(0).function().arguments());
+			})
 			.verifyComplete();
 	}
 

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelperTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelperTests.java
@@ -130,6 +130,40 @@ public class DashScopeAiStreamFunctionCallingHelperTests {
 	}
 
 	@Test
+	void mergeStreamingToolCallChunksClosesOnToolCallStop() {
+		ChatCompletionChunk first = createChunkWithToolCall("request-1", "tool-1", "get_weather",
+				"{\"city\":\"Bei");
+		ChatCompletionChunk stop = createChunkWithToolCall("request-1", null, null, "jing\"}",
+				ChatCompletionFinishReason.STOP);
+
+		StepVerifier.create(helperWithIncrementalOutput.mergeStreamingToolCallChunks(Flux.just(first, stop)))
+			.expectNext(first, stop)
+			.assertNext(merged -> {
+				assertEquals(ChatCompletionFinishReason.STOP, merged.output().choices().get(0).finishReason());
+				assertEquals("{\"city\":\"Beijing\"}",
+						merged.output().choices().get(0).message().toolCalls().get(0).function().arguments());
+			})
+			.verifyComplete();
+	}
+
+	@Test
+	void mergeStreamingToolCallChunksClosesOnToolCallLength() {
+		ChatCompletionChunk first = createChunkWithToolCall("request-1", "tool-1", "get_weather",
+				"{\"city\":\"Bei");
+		ChatCompletionChunk length = createChunkWithToolCall("request-1", null, null, "jing\"}",
+				ChatCompletionFinishReason.LENGTH);
+
+		StepVerifier.create(helperWithIncrementalOutput.mergeStreamingToolCallChunks(Flux.just(first, length)))
+			.expectNext(first, length)
+			.assertNext(merged -> {
+				assertEquals(ChatCompletionFinishReason.LENGTH, merged.output().choices().get(0).finishReason());
+				assertEquals("{\"city\":\"Beijing\"}",
+						merged.output().choices().get(0).message().toolCalls().get(0).function().arguments());
+			})
+			.verifyComplete();
+	}
+
+	@Test
 	void mergeStreamingToolCallChunksFlushesMergedChunkOnCompletion() {
 		ChatCompletionChunk first = createChunkWithToolCall("request-1", "tool-1", "get_weather",
 				"{\"city\":\"Bei");

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
@@ -66,6 +66,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -364,6 +365,42 @@ class DashScopeChatModelTests {
         assertThat(responses.get(1).hasToolCalls()).isTrue();
         verify(toolCallingManager).executeToolCalls(any(), any());
     }
+
+	@Test
+	void lengthTerminatedStreamingToolCallExecutesMergedCallOnce() {
+		ToolCallingManager toolCallingManager = mock(ToolCallingManager.class);
+		ToolResponseMessage toolResponse = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("tool-1", "get_weather", "sunny")))
+			.build();
+		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+			.conversationHistory(List.of(toolResponse))
+			.returnDirect(true)
+			.build();
+		when(toolCallingManager.executeToolCalls(any(), any())).thenReturn(toolExecutionResult);
+		DashScopeChatModel toolChatModel = DashScopeChatModel.builder()
+			.dashScopeApi(dashScopeApi)
+			.defaultOptions(defaultOptions)
+			.toolCallingManager(toolCallingManager)
+			.build();
+
+		ToolCall firstFragment = new ToolCall("tool-1", "function",
+				new ChatCompletionFunction("get_weather", "{\"city\":\"Bei"), 0);
+		ToolCall terminalFragment = new ToolCall("tool-1", "function",
+				new ChatCompletionFunction("get_weather", "jing\"}"), 0);
+		ToolCall mergedToolCall = new ToolCall("tool-1", "function",
+				new ChatCompletionFunction("get_weather", "{\"city\":\"Beijing\"}"), 0);
+		ChatCompletionChunk first = createToolCallChunk(firstFragment, null);
+		ChatCompletionChunk terminal = createToolCallChunk(terminalFragment, ChatCompletionFinishReason.LENGTH);
+		ChatCompletionChunk merged = createToolCallChunk(mergedToolCall, ChatCompletionFinishReason.LENGTH);
+		when(dashScopeApi.chatCompletionStream(any(), any())).thenReturn(Flux.just(first, terminal, merged));
+
+		List<ChatResponse> responses = toolChatModel.stream(new Prompt(new UserMessage(TEST_PROMPT)))
+			.collectList()
+			.block();
+
+		assertThat(responses).hasSize(3);
+		verify(toolCallingManager, times(1)).executeToolCalls(any(), any());
+	}
 
     @Test
     void testErrorHandling() {

--- a/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
+++ b/models/dashscope/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
@@ -51,6 +51,7 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.DefaultToolDefinition;
@@ -64,6 +65,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -297,6 +300,72 @@ class DashScopeChatModelTests {
     }
 
     @Test
+    void incompleteStreamingToolCallsDoNotBecomeEligibleForInternalExecution() {
+        ToolCallingManager toolCallingManager = mock(ToolCallingManager.class);
+        DashScopeChatModel toolChatModel = DashScopeChatModel.builder()
+                .dashScopeApi(dashScopeApi)
+                .defaultOptions(defaultOptions)
+                .toolCallingManager(toolCallingManager)
+                .build();
+
+        ToolCall firstToolCall = new ToolCall("tool-1", "function",
+                new ChatCompletionFunction("get_weather", "{\"city\":\"Bei"), 0);
+        ToolCall terminalButInvalidToolCall = new ToolCall("tool-1", "function",
+                new ChatCompletionFunction("get_weather", "jing\"}"), 0);
+        ChatCompletionChunk first = createToolCallChunk(firstToolCall, null);
+        ChatCompletionChunk terminalButInvalid = createToolCallChunk(terminalButInvalidToolCall,
+                ChatCompletionFinishReason.TOOL_CALLS);
+
+        when(dashScopeApi.chatCompletionStream(any(), any()))
+                .thenReturn(Flux.just(first, terminalButInvalid));
+
+        List<ChatResponse> responses = toolChatModel.stream(new Prompt(new UserMessage(TEST_PROMPT)))
+                .collectList().block();
+
+        assertThat(responses).hasSize(2)
+                .allSatisfy(response -> assertThat(response.hasToolCalls()).isTrue());
+        verify(toolCallingManager, never()).executeToolCalls(any(), any());
+    }
+
+    @Test
+    void completeTerminalToolCallRemainsEligibleForInternalExecution() {
+        ToolCallingManager toolCallingManager = mock(ToolCallingManager.class);
+        ToolResponseMessage toolResponse = ToolResponseMessage.builder()
+                .responses(List.of(new ToolResponseMessage.ToolResponse("tool-1", "get_weather", "sunny")))
+                .build();
+        ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+                .conversationHistory(List.of(toolResponse))
+                .returnDirect(true)
+                .build();
+        when(toolCallingManager.executeToolCalls(any(), any())).thenReturn(toolExecutionResult);
+        DashScopeChatModel toolChatModel = DashScopeChatModel.builder()
+                .dashScopeApi(dashScopeApi)
+                .defaultOptions(defaultOptions)
+                .toolCallingManager(toolCallingManager)
+                .build();
+
+        ToolCall firstFragment = new ToolCall("tool-1", "function",
+                new ChatCompletionFunction("get_weather", "{\"city\":\"Bei"), 0);
+        ToolCall secondFragment = new ToolCall("tool-1", "function",
+                new ChatCompletionFunction("get_weather", "jing\"}"), 0);
+        ToolCall completeToolCall = new ToolCall("tool-1", "function",
+                new ChatCompletionFunction("get_weather", "{\"city\":\"Beijing\"}"), 0);
+        ChatCompletionChunk first = createToolCallChunk(firstFragment, null);
+        ChatCompletionChunk second = createToolCallChunk(secondFragment, null);
+        ChatCompletionChunk complete = createToolCallChunk(completeToolCall,
+                ChatCompletionFinishReason.TOOL_CALLS);
+        when(dashScopeApi.chatCompletionStream(any(), any())).thenReturn(Flux.just(first, second, complete));
+
+        List<ChatResponse> responses = toolChatModel.stream(new Prompt(new UserMessage(TEST_PROMPT)))
+                .collectList().block();
+
+        assertThat(responses).hasSize(3);
+        assertThat(responses.get(0).hasToolCalls()).isTrue();
+        assertThat(responses.get(1).hasToolCalls()).isTrue();
+        verify(toolCallingManager).executeToolCalls(any(), any());
+    }
+
+    @Test
     void testErrorHandling() {
         // Test error handling
         when(dashScopeApi.chatCompletionEntity(any(), any())).thenThrow(new RuntimeException("API Error"));
@@ -305,6 +374,15 @@ class DashScopeChatModelTests {
         Prompt prompt = new Prompt(List.of(message));
 
         assertThatThrownBy(() -> chatModel.call(prompt)).isInstanceOf(RuntimeException.class).hasMessage("API Error");
+    }
+
+    private ChatCompletionChunk createToolCallChunk(ToolCall toolCall,
+            ChatCompletionFinishReason finishReason) {
+        ChatCompletionMessage message = new ChatCompletionMessage("", ChatCompletionMessage.Role.ASSISTANT,
+                null, null, List.of(toolCall), null, null, null, null, null);
+        Choice choice = new Choice(finishReason, message, null, 0);
+        return new ChatCompletionChunk(TEST_REQUEST_ID,
+                new ChatCompletionOutput("", List.of(choice), null), null, null);
     }
 
     @Test


### PR DESCRIPTION
### Describe what this PR does / why we need it

`DashScopeApi.chatCompletionStream()` currently groups tool-call chunks with `windowUntil(...).reduce(...)`. This happens in the provider adapter, so downstream consumers only receive the merged tool call and cannot render argument fragments as they arrive.

This PR emits every raw tool-call chunk in order and then emits the final merged chunk. Ordinary text chunks continue to pass through unchanged.

### Does this pull request fix one issue?

Fixes alibaba/spring-ai-alibaba#3881

### Describe how you did it

- Moved streaming tool-call orchestration into a package-private `DashScopeAiStreamFunctionCallingHelper.mergeStreamingToolCallChunks(...)` method while reusing the existing `merge(...)` behavior.
- Kept merge state per subscription and flush the merged tool call on `TOOL_CALLS`, another terminal finish reason such as `STOP`, or normal stream completion.
- Avoided emitting a duplicate when one tool-call chunk is already complete.
- Preserved existing `incremental_output=true/false`, null id/function-name, and tool-call index merge behavior.
- Added a streaming execution guard in `DashScopeChatModel`: intermediate tool-call responses remain visible with `hasToolCalls()==true`, but internal execution is considered only after a terminal finish reason and complete valid JSON arguments. The completed merged tool call remains executable.

### Describe how to verify it

- `mvn -pl models/dashscope -Dtest=DashScopeAiStreamFunctionCallingHelperTests,DashScopeChatModelTests test`
  - 62 tests, 0 failures, 0 errors
- `mvn -pl models/dashscope test`
  - 570 tests, 0 failures, 0 errors, 31 skipped
- `mvn -pl models/dashscope spotless:check`
- `mvn -pl models/dashscope -Dcheckstyle.skip=false checkstyle:check`
  - 0 Checkstyle violations
- `git diff --check`

### Special notes for reviews

The implementation intentionally does not change global `AssistantMessage.hasToolCalls()` semantics and does not add a public configuration switch. Regression coverage includes fragment ordering, complete merged arguments, ordinary text pass-through, single-chunk deduplication, `STOP`/completion flushing, non-incremental output, incomplete-fragment execution blocking, and completed-tool execution.
