### PR TITLE
fix(mcp): align JSON Schema validator with MCP SDK

### DIFF
--- a/mcp/spring-ai-alibaba-mcp-common/pom.xml
+++ b/mcp/spring-ai-alibaba-mcp-common/pom.xml
@@ -52,10 +52,6 @@
         <url>https://github.com/alibaba/spring-ai-alibaba</url>
     </scm>
 
-    <properties>
-        <json-schema-validator.version>1.5.3</json-schema-validator.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -65,27 +61,9 @@
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-mcp</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.networknt</groupId>
-                    <artifactId>json-schema-validator</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
-        <!-- Manually add compatible version of json-schema-validator with Jackson exclusions -->
-        <dependency>
-            <groupId>com.networknt</groupId>
-            <artifactId>json-schema-validator</artifactId>
-            <version>${json-schema-validator.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.dataformat</groupId>
-                    <artifactId>jackson-dataformat-yaml</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
+        <!-- Keep the JSON Schema validator aligned with the selected MCP SDK. Its 1.x and 2.x APIs are not binary compatible. -->
         <dependency>
             <groupId>io.modelcontextprotocol.sdk</groupId>
             <artifactId>mcp-spring-webflux</artifactId>


### PR DESCRIPTION
### Describe what this PR does / why we need it

Removes the hard-coded `json-schema-validator` 1.5.3 override from `spring-ai-alibaba-mcp-common` and lets the selected MCP SDK provide its compatible validator version.

The forced 1.5.3 dependency wins Maven conflict resolution even when Spring AI 1.1.6 selects MCP SDK 0.18.2. That SDK was compiled against `json-schema-validator` 2.0.0, so startup fails with `NoClassDefFoundError: com/networknt/schema/dialect/Dialects`.

### Does this pull request fix one issue?

Fixes alibaba/spring-ai-alibaba#4619

### Describe how you did it

Removed the explicit validator version, the exclusion from `spring-ai-mcp`, and the replacement direct dependency. The validator now follows the MCP SDK dependency graph:

- MCP SDK 0.14.0 resolves validator 1.5.7
- MCP SDK 0.18.2 resolves validator 2.0.0

### Describe how to verify it

- `mvn -pl mcp/spring-ai-alibaba-mcp-registry -am test`
- `mvn -pl mcp/spring-ai-alibaba-mcp-registry -am test -Dspring-ai.version=1.1.6 -Dmcp.version=0.18.2`
- `mvn -pl mcp/spring-ai-alibaba-mcp-common,mcp/spring-ai-alibaba-mcp-distributed,mcp/spring-ai-alibaba-mcp-gateway,mcp/spring-ai-alibaba-mcp-registry,mcp/spring-ai-alibaba-mcp-router -am test`
- `mvn -pl mcp/spring-ai-alibaba-mcp-common,mcp/spring-ai-alibaba-mcp-registry spotless:check`

### Special notes for reviews

This intentionally avoids pinning a validator version in the extension because MCP SDK 0.14.x and 0.18.x use binary-incompatible validator major versions.